### PR TITLE
Use known time_zone for Scheduler job.

### DIFF
--- a/terraform/modules/scheduler/main.tf
+++ b/terraform/modules/scheduler/main.tf
@@ -23,6 +23,7 @@ resource "google_cloud_scheduler_job" "poller_job" {
   name        = "poll-main-instance-metrics"
   description = "Poll metrics for main-instance"
   schedule    = var.schedule
+  time_zone   = var.time_zone
 
   pubsub_target {
     topic_name = var.pubsub_topic

--- a/terraform/modules/scheduler/variables.tf
+++ b/terraform/modules/scheduler/variables.tf
@@ -28,6 +28,11 @@ variable "schedule" {
   default = "*/2 * * * *"
 }
 
+variable "time_zone" {
+  type    = string
+  default = "America/Los_Angeles"
+}
+
 variable "pubsub_topic" {
   type    = string
 }


### PR DESCRIPTION
Cloud Scheduler UI does not know about the default Etc/UTC time zone
so use a known timezone instead to prevent UI errors.