### PR TITLE
Adding a GitHub Action to run markdownlint 

### DIFF
--- a/.github/linters.yaml
+++ b/.github/linters.yaml
@@ -1,0 +1,14 @@
+name: markdownlint
+
+on: [push, pull_request]
+
+jobs:
+  delivery:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@master
+    - name: Run mdl
+      uses: actionshub/markdownlint@master


### PR DESCRIPTION
Starting to work on Issue #16.

Fixed some additional markdown linter issues and adding a GitHub Action to automate linting.

