### PR TITLE
Including prefix

### DIFF
--- a/terraform/modules/autoscaler/main.tf
+++ b/terraform/modules/autoscaler/main.tf
@@ -18,12 +18,12 @@
 // Service Accounts
 
 resource "google_service_account" "poller_sa" {
-  account_id   = "poller-sa"
+  account_id   = "${var.prefix!= "" ? "${var.prefix}-" : ""}poller-sa"
   display_name = "Autoscaler - Metrics Poller Service Account"
 }
 
 resource "google_service_account" "scaler_sa" {
-  account_id   = "scaler-sa"
+  account_id   = "${var.prefix!= "" ? "${var.prefix}-" : ""}scaler-sa"
   display_name = "Autoscaler - Scaler Function Service Account"
 }
 
@@ -39,7 +39,7 @@ resource "google_project_iam_binding" "scaler_sa_firestore" {
 // PubSub
 
 resource "google_pubsub_topic" "poller_topic" {
-  name = "poller-topic"
+  name = "${var.prefix!= "" ? "${var.prefix}-" : ""}poller-topic"
 }
 
 resource "google_pubsub_topic_iam_binding" "poller_pubsub_sub_binding" {
@@ -59,7 +59,7 @@ resource "google_pubsub_topic_iam_binding" "forwarder_pubsub_pub_binding" {
 }
 
 resource "google_pubsub_topic" "scaler_topic" {
-  name = "scaler-topic"
+  name = "${var.prefix!= "" ? "${var.prefix}-" : ""}scaler-topic"
 }
 
 resource "google_pubsub_topic_iam_binding" "poller_pubsub_pub_binding" {
@@ -96,7 +96,7 @@ data "archive_file" "local_poller_source" {
 }
 
 resource "google_storage_bucket_object" "gcs_functions_poller_source" {
-  name   = "poller.${data.archive_file.local_poller_source.output_md5}.zip"
+  name   = "${var.prefix!= "" ? "${var.prefix}-" : ""}poller.${data.archive_file.local_poller_source.output_md5}.zip"
   bucket = google_storage_bucket.bucket_gcf_source.name
   source = data.archive_file.local_poller_source.output_path
 }
@@ -108,13 +108,13 @@ data "archive_file" "local_scaler_source" {
 }
 
 resource "google_storage_bucket_object" "gcs_functions_scaler_source" {
-  name   = "scaler.${data.archive_file.local_scaler_source.output_md5}.zip"
+  name   = "${var.prefix!= "" ? "${var.prefix}-" : ""}scaler.${data.archive_file.local_scaler_source.output_md5}.zip"
   bucket = google_storage_bucket.bucket_gcf_source.name
   source = data.archive_file.local_scaler_source.output_path
 }
 
 resource "google_cloudfunctions_function" "poller_function" {
-  name = "tf-poller-function"
+  name = "${var.prefix!= "" ? "${var.prefix}-" : ""}poller-function"
   project = var.project_id
   region = var.region
   available_memory_mb = "256"
@@ -130,7 +130,7 @@ resource "google_cloudfunctions_function" "poller_function" {
 }
 
 resource "google_cloudfunctions_function" "scaler_function" {
-  name = "tf-scaler-function"
+  name = "${var.prefix!= "" ? "${var.prefix}-" : ""}scaler-function"
   project = var.project_id
   region = var.region
   available_memory_mb = "256"

--- a/terraform/modules/autoscaler/variables.tf
+++ b/terraform/modules/autoscaler/variables.tf
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-variable "prefix" {
-  type = string
-  default = ""
-}
-
 variable "project_id" {
   type = string
 }
@@ -37,4 +32,9 @@ variable "forwarder_sa_emails" {
   type    = list(string)
   // Example ["serviceAccount:forwarder_sa@app-project.iam.gserviceaccount.com"]
   default = []
+}
+
+variable "prefix" {
+  type = string
+  default = ""
 }

--- a/terraform/modules/autoscaler/variables.tf
+++ b/terraform/modules/autoscaler/variables.tf
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+variable "prefix" {
+  type = string
+  default = ""
+}
+
 variable "project_id" {
   type = string
 }

--- a/terraform/modules/forwarder/main.tf
+++ b/terraform/modules/forwarder/main.tf
@@ -18,14 +18,14 @@
 // Service Accounts
 
 resource "google_service_account" "forwarder_sa" {
-  account_id   = "forwarder-sa"
+  account_id   = "${var.prefix!= "" ? "${var.prefix}-" : ""}forwarder-sa"
   display_name = "Autoscaler - PubSub Forwarder Service Account"
 }
 
 // PubSub
 
 resource "google_pubsub_topic" "forwarder_topic" {
-  name = "forwarder-topic"
+  name = "${var.prefix!= "" ? "${var.prefix}-" : ""}forwarder-topic"
 }
 
 resource "google_pubsub_topic_iam_binding" "forwader_pubsub_sub_binding" {
@@ -53,13 +53,13 @@ data "archive_file" "local_forwarder_source" {
 }
 
 resource "google_storage_bucket_object" "gcs_functions_forwarder_source" {
-  name   = "forwarder.${data.archive_file.local_forwarder_source.output_md5}.zip"
+  name   = "${var.prefix!= "" ? "${var.prefix}-" : ""}forwarder.${data.archive_file.local_forwarder_source.output_md5}.zip"
   bucket = google_storage_bucket.bucket_gcf_source.name
   source = data.archive_file.local_forwarder_source.output_path
 }
 
 resource "google_cloudfunctions_function" "forwarder_function" {
-  name = "tf-forwarder-function"
+  name = "${var.prefix!= "" ? "${var.prefix}-" : ""}forwarder-function"
   project = var.project_id
   region = var.region
   available_memory_mb = "256"

--- a/terraform/modules/forwarder/variables.tf
+++ b/terraform/modules/forwarder/variables.tf
@@ -31,3 +31,8 @@ variable "local_output_path" {
 variable "target_pubsub_topic" {
   type    = string
 }
+
+variable "prefix" {
+  type = string
+  default = ""
+}

--- a/terraform/modules/scheduler/main.tf
+++ b/terraform/modules/scheduler/main.tf
@@ -20,7 +20,7 @@ resource "google_app_engine_application" "app" {
 }
 
 resource "google_cloud_scheduler_job" "poller_job" {
-  name        = "poll-main-instance-metrics"
+  name        = "${var.prefix!= "" ? "${var.prefix}-" : ""}poll-main-instance-metrics"
   description = "Poll metrics for main-instance"
   schedule    = var.schedule
   time_zone   = var.time_zone

--- a/terraform/modules/scheduler/main.tf
+++ b/terraform/modules/scheduler/main.tf
@@ -24,6 +24,7 @@ resource "google_cloud_scheduler_job" "poller_job" {
   description = "Poll metrics for main-instance"
   schedule    = var.schedule
   time_zone   = var.time_zone
+  region      = var.region
 
   pubsub_target {
     topic_name = var.pubsub_topic

--- a/terraform/modules/scheduler/variables.tf
+++ b/terraform/modules/scheduler/variables.tf
@@ -23,6 +23,11 @@ variable "location" {
   default = "us-central"
 }
 
+variable "region" {
+  type    = string
+  default = "us-central1"
+}
+
 variable "schedule" {
   type    = string
   default = "*/2 * * * *"

--- a/terraform/modules/scheduler/variables.tf
+++ b/terraform/modules/scheduler/variables.tf
@@ -40,3 +40,8 @@ variable "pubsub_topic" {
 variable "pubsub_data" {
   type    = string
 }
+
+variable "prefix" {
+  type = string
+  default = ""
+}

--- a/terraform/per-project/.terraform.lock.hcl
+++ b/terraform/per-project/.terraform.lock.hcl
@@ -1,0 +1,37 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.0.0"
+  hashes = [
+    "h1:WWGcM4hCkZLObytvhPHxR/s6FR7+jhNHGQ+2DYvBKbI=",
+    "zh:1c3300a6686481ed0b3ce456949805b5c55f901b77108543046f12118a102914",
+    "zh:2d44bcc8a5ea3f2c2ff54ca4c4b273cdc3500ad8bb6929eec6722bb9d10a9714",
+    "zh:4be17c4e06a74ca30a3c9e88446e453ad16c493b2ddef872a6580dbfe618a1b4",
+    "zh:50c216a6c672b51d67ece37ce69c121acbcd5c8d24b899e876c61bc09989f69f",
+    "zh:90d6ad51fecab8d2f086aab9ed45020f1a9d3627dbc95edda11af8e3f87082d9",
+    "zh:d147427135330b4940a85a0f552e2c1f83a0d1ccdcc82c36a2d311b7f85dbd38",
+    "zh:dd4b8c0b113e37fd83ceab0f8a203ccfa39caaca5551c70a94fa61e900902932",
+    "zh:e30ef64a2ed0c2a6e8d1e29b8da8b05b4a303e256478a4b410af81c81cbcbc23",
+    "zh:e5a81379810d3e1f380b7145d0ecee4a69ab4e80184f77b66cd4411b86aca6a8",
+    "zh:f9a0a2a72721e7e047e83053173b3a68a7d53e2a22719cc2d9234dbee46c466c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "3.53.0"
+  constraints = "> 3.5.0"
+  hashes = [
+    "h1:0MYwK1KRNCc9lfF8vV9gDEuaylwEfSPws7ZJbLwY2FE=",
+    "zh:1408365b5f2ae508fce9b446bb9dbaf044aec81fa4c36fff39c2511b179bcc56",
+    "zh:1d53e978065feb6278bc8c88a70c3df7599c3b8bbcd77765bcd842a83bce6686",
+    "zh:5173a92249c8d06d0d2beca0e328df6e956becd789ebae9a064f022151415b8f",
+    "zh:5bd2ee6cd6baf2cb429f82140cbb5e6c90362b0ef4edaf63df30520e01507374",
+    "zh:65670355fddde75bfadc088627e2700dc14054a63aa5434d2759e7fe43b989c6",
+    "zh:97d4382855c50a2077d3ecd241a02324b8ba2cb8b8c76f8f896c40189260f6c1",
+    "zh:9a18ad92e062dcd2ef72ed9021d5827326a2fc13c2c442c54baf6a9298035873",
+    "zh:b4941a0f47f05c965af42821d51748ac326aea2843b123663dd50f7075fa1956",
+    "zh:f40bbb7046dfcd12ddef175acb1cfc4a8ae082f56a24ba413f0719747789915b",
+    "zh:f60769112a2e36beb762dc7f31916f818b5cacfb35d7d8ddeb40ea6bf8690e9e",
+  ]
+}

--- a/terraform/per-project/main.tf
+++ b/terraform/per-project/main.tf
@@ -16,9 +16,6 @@
 
 provider "google" {
     version = ">3.5.0"
-
-    credentials = file("${var.creds_file}")
-
     project = var.project_id
     region  = var.region
     zone    = var.zone
@@ -26,7 +23,7 @@ provider "google" {
 
 module "autoscaler" {
   source = "../modules/autoscaler"
-
+  credentials = file("${var.creds_file}")
   project_id = var.project_id
 }
 


### PR DESCRIPTION
We need a prefix to highlight that this service is ours.

# Test
Create a file with name `main.tf`and containing text bellow.

```
variable "project_id" {
    type = string
}

variable "spanner_name" {
    type = string
}

variable "max_nodes" {
    type = number
}

provider "google" {
    version = ">3.5.0"
    project = var.project_id
}

module "autoscaler" {
  source = "git@github.com:ResultadosDigitais/autoscaler.git//terraform/modules/autoscaler?ref=prefix"
  project_id = var.project_id
  prefix = "my-prefix"
}

module "spanner" {
  source  = "git@github.com:ResultadosDigitais/autoscaler.git//terraform/modules/spanner?ref=prefix"

  terraform_spanner = false
  project_id        = var.project_id
  spanner_name      = var.spanner_name
  poller_sa_email   = module.autoscaler.poller_sa_email
  scaler_sa_email   = module.autoscaler.scaler_sa_email
}

module "scheduler" {
  source  = "git@github.com:ResultadosDigitais/autoscaler.git//terraform/modules/scheduler?ref=prefix"
  prefix = "my-prefix"

  project_id   = var.project_id
  pubsub_topic = module.autoscaler.poller_topic
  pubsub_data  = base64encode(jsonencode([
    {
      "projectId": "${var.project_id}", 
      "instanceId": "${var.spanner_name}", 
      "scalerPubSubTopic": "${module.autoscaler.scaler_topic}", 
      "minNodes": 1, 
      "maxNodes": var.max_nodes, 
      "scalingMethod": "LINEAR", 
      "scaleInCoolingMinutes": 1,
      "metrics": [{"name": "high_priority_cpu","regional_threshold": 65,"regional_margin": 3}]
      }
    ]))
}
```

Import app engine:
```
terraform import module.scheduler.google_app_engine_application.app "my-project"
```
Execute terraform plan:
```
terraform plan -var="project_id=my-project" -var="max_nodes=10" -var="spanner_name=my-spanner"
```

Check if plan is correct and execute terraform plan:
```
terraform apply -var="project_id=my-project" -var="max_nodes=10" -var="spanner_name=my-spanner"
```
