### PR TITLE
Issue #39 - Updating Terraform to use the safer iam_member instead of binding.

### DIFF
--- a/terraform/modules/autoscaler/main.tf
+++ b/terraform/modules/autoscaler/main.tf
@@ -27,13 +27,11 @@ resource "google_service_account" "scaler_sa" {
   display_name = "Autoscaler - Scaler Function Service Account"
 }
 
-resource "google_project_iam_binding" "scaler_sa_firestore" {
+resource "google_project_iam_member" "scaler_sa_firestore" {
   project = var.project_id
   role    = "roles/datastore.user"
 
-  members = [
-    "serviceAccount:${google_service_account.scaler_sa.email}",
-  ]
+  member = "serviceAccount:${google_service_account.scaler_sa.email}"
 }
 
 // PubSub
@@ -42,42 +40,38 @@ resource "google_pubsub_topic" "poller_topic" {
   name = "poller-topic"
 }
 
-resource "google_pubsub_topic_iam_binding" "poller_pubsub_sub_binding" {
+resource "google_pubsub_topic_iam_member" "poller_pubsub_sub_iam" {
   project = var.project_id
-  topic = google_pubsub_topic.poller_topic.name
-  role = "roles/pubsub.subscriber"
-  members = [
-    "serviceAccount:${google_service_account.poller_sa.email}",
-  ]
+  topic   = google_pubsub_topic.poller_topic.name
+  role    = "roles/pubsub.subscriber"
+  member  = "serviceAccount:${google_service_account.poller_sa.email}"
 }
 
-resource "google_pubsub_topic_iam_binding" "forwarder_pubsub_pub_binding" {
+resource "google_pubsub_topic_iam_member" "forwarder_pubsub_pub_iam" {
+  for_each = toset(var.forwarder_sa_emails)
+
   project = var.project_id
-  topic = google_pubsub_topic.poller_topic.name
-  role = "roles/pubsub.publisher"
-  members = var.forwarder_sa_emails
+  topic   = google_pubsub_topic.poller_topic.name
+  role    = "roles/pubsub.publisher"
+  member = each.key
 }
 
 resource "google_pubsub_topic" "scaler_topic" {
   name = "scaler-topic"
 }
 
-resource "google_pubsub_topic_iam_binding" "poller_pubsub_pub_binding" {
+resource "google_pubsub_topic_iam_member" "poller_pubsub_pub_iam" {
   project = var.project_id
-  topic = google_pubsub_topic.scaler_topic.name
-  role = "roles/pubsub.publisher"
-  members = [
-    "serviceAccount:${google_service_account.poller_sa.email}",
-  ]
+  topic   = google_pubsub_topic.scaler_topic.name
+  role    = "roles/pubsub.publisher"
+  member  = "serviceAccount:${google_service_account.poller_sa.email}"
 }
 
-resource "google_pubsub_topic_iam_binding" "scaler_pubsub_sub_binding" {
+resource "google_pubsub_topic_iam_member" "scaler_pubsub_sub_iam" {
   project = var.project_id
-  topic = google_pubsub_topic.scaler_topic.name
-  role = "roles/pubsub.subscriber"
-  members = [
-    "serviceAccount:${google_service_account.scaler_sa.email}",
-  ]
+  topic   = google_pubsub_topic.scaler_topic.name
+  role    = "roles/pubsub.subscriber"
+  member  = "serviceAccount:${google_service_account.scaler_sa.email}"
 }
 
 // Cloud Functions

--- a/terraform/modules/forwarder/main.tf
+++ b/terraform/modules/forwarder/main.tf
@@ -28,13 +28,11 @@ resource "google_pubsub_topic" "forwarder_topic" {
   name = "forwarder-topic"
 }
 
-resource "google_pubsub_topic_iam_binding" "forwader_pubsub_sub_binding" {
+resource "google_pubsub_topic_iam_member" "forwader_pubsub_sub_binding" {
   project = var.project_id
-  topic = google_pubsub_topic.forwarder_topic.name
-  role = "roles/pubsub.subscriber"
-  members = [
-    "serviceAccount:${google_service_account.forwarder_sa.email}",
-  ]
+  topic   = google_pubsub_topic.forwarder_topic.name
+  role    = "roles/pubsub.subscriber"
+  member  = "serviceAccount:${google_service_account.forwarder_sa.email}"
 }
 
 // Cloud Functions

--- a/terraform/modules/spanner/main.tf
+++ b/terraform/modules/spanner/main.tf
@@ -38,35 +38,28 @@ resource "google_spanner_database" "database" {
   depends_on = [google_spanner_instance.main]
 }
 
-resource "google_spanner_instance_iam_binding" "spanner_metadata_get_binding" {
+resource "google_spanner_instance_iam_member" "spanner_metadata_get_iam" {
   instance = var.spanner_name
-  role = "roles/spanner.viewer"
-  project      = var.project_id
+  role     = "roles/spanner.viewer"
+  project  = var.project_id
+  member   = "serviceAccount:${var.poller_sa_email}"
 
-  members = [
-    "serviceAccount:${var.poller_sa_email}",
-  ]
   depends_on = [google_spanner_instance.main]
 }
 
-resource "google_spanner_instance_iam_binding" "spanner_admin_binding" {
+resource "google_spanner_instance_iam_member" "spanner_admin_iam" {
   # Allows scaler to change the number of nodes of the Spanner instance
   instance = var.spanner_name
-  role = "roles/spanner.admin"
-  project      = var.project_id
+  role     = "roles/spanner.admin"
+  project  = var.project_id
+  member   = "serviceAccount:${var.scaler_sa_email}"
 
-  members = [
-    "serviceAccount:${var.scaler_sa_email}",
-  ]
   depends_on = [google_spanner_instance.main]
 }
 
-resource "google_project_iam_binding" "poller_sa_cloud_monitoring" {
+resource "google_project_iam_member" "poller_sa_cloud_monitoring" {
   # Allows poller to get Spanner metrics
   role    = "roles/monitoring.viewer"
   project = var.project_id
-
-  members = [
-    "serviceAccount:${var.poller_sa_email}",
-  ]
+  member  = "serviceAccount:${var.poller_sa_email}"
 }


### PR DESCRIPTION
As described in Issue #39 the modules were using iam_binding which is authoritative which will override any pre-existing roles, which is likely the case with Cloud Spanner deployments. This update changes to iam_member which is an additive which will be safer for resources which might already have iam roles.