### PR TITLE
Fixing the markdown linter action

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -9,8 +9,8 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@master
+      uses: actions/checkout@v2
     - name: Run mdl
-      uses: actionshub/markdownlint@master
+      uses: actionshub/markdownlint@main
       with:
         filesToIgnoreRegex: code\-of\-conduct\.md


### PR DESCRIPTION
Markdown linting broke because the tag for the markdown linter got changed to `main`.  This PR updates the actions to use the correct tag. 