### PR TITLE
Added support for processing units in the configuration processing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@
 
 ## Overview
 
-The Autoscaler tool for Cloud Spanner is a companion tool to Cloud Spanner that allows
-you to automatically increase or reduce the number of nodes or processing units in one
-or more Spanner instances, based on their utilization.
+The Autoscaler tool for Cloud Spanner is a companion tool to Cloud Spanner
+that allows you to automatically increase or reduce the number of nodes or
+processing units in one or more Spanner instances, based on their utilization.
 
 When you create a [Cloud Spanner instance][spanner-instance], you choose the
 number of nodes or processing units that provide compute resources for the

--- a/README.md
+++ b/README.md
@@ -31,16 +31,16 @@
 ## Overview
 
 The Autoscaler tool for Cloud Spanner is a companion tool to Cloud Spanner that allows
-you to automatically increase or reduce the number of nodes in one or more
-Spanner instances, based on their utilization.
+you to automatically increase or reduce the number of nodes or processing units in one
+or more Spanner instances, based on their utilization.
 
 When you create a [Cloud Spanner instance][spanner-instance], you choose the
-number of nodes that provide compute resources for the instance. As the
-instance's workload changes, Cloud Spanner does *not* automatically adjust the
-number of nodes in the instance.
+number of nodes or processing units that provide compute resources for the
+instance. As the instance's workload changes, Cloud Spanner does *not*
+automatically adjust the number of nodes or processing units in the instance.
 
 The Autoscaler monitors your instances and automatically adds or
-removes nodes to ensure that they stay within the
+removes compute capacity to ensure that they stay within the
 [recommended maximums for CPU utilization][spanner-max-cpu] and the
 [recommended limit for storage per node][spanner-max-storage], plus or minus an
 [allowed margin](poller/README.md#margins). Note that the recommended thresholds
@@ -84,7 +84,7 @@ interaction flow:
     Scaler function compares the Spanner instance metrics against the
     recommended thresholds, plus or minus an [allowed margin](poller/README.md#margins)
     and determines if the instance should be scaled, and the number of nodes
-    that it should be scaled to.
+    or processiing units that it should be scaled to.
 
 7.  The Scaler function retrieves the time when the instance was last scaled
     from the state data stored in [Cloud Firestore][cloud-firestore] and
@@ -146,14 +146,16 @@ After deploying the Autoscaler, you are ready to configure its parameters.
         "projectId": "my-spanner-project",
         "instanceId": "spanner1",
         "scalerPubSubTopic": "projects/my-spanner-project/topics/spanner-scaling",
-        "minNodes": 1,
-        "maxNodes": 3
+        "units": "NODES",
+        "minSize": 1,
+        "maxSize": 3
     },{
         "projectId": "different-project",
         "instanceId": "another-spanner1",
         "scalerPubSubTopic": "projects/my-spanner-project/topics/spanner-scaling",
-        "minNodes": 5,
-        "maxNodes": 30,
+        "units": "PROCESSING_UNITS",
+        "minSize": 500,
+        "maxSize": 3000,
         "scalingMethod": "DIRECT"
     }
 ]

--- a/poller/README.md
+++ b/poller/README.md
@@ -75,18 +75,18 @@ instructions on how to change the payload.
 Key                      | Default Value  | Description
 ------------------------ | -------------- | -----------
 `units`                  | `NODES`        | Specifies the units that capacity will be measured in `NODES` or `PROCESSING_UNITS`.
-`minSize`                | 1 or 100       | Minimum number of Cloud Spanner nodes or processing units that the instance can be scaled IN to.
-`maxSize`                | 3 or 2000      | Maximum number of Cloud Spanner nodes or processing units that the instance can be scaled OUT to.
-`minNodes`               | 1              | DEPRECATED: Minimum number of Cloud Spanner nodes that the instance can be scaled IN to.
-`maxNodes`               | 3              | DEPRECATED: Maximum number of Cloud Spanner nodes that the instance can be scaled OUT to.
+`minSize`                | 1 N or 100 PU  | Minimum number of Cloud Spanner nodes or processing units that the instance can be scaled IN to.
+`maxSize`                | 3 N or 2000 PU | Maximum number of Cloud Spanner nodes or processing units that the instance can be scaled OUT to.
 `scalingMethod`          | `STEPWISE`     | Scaling method that should be used. Options are: `STEPWISE`, `LINEAR`, `DIRECT`. See the [scaling methods section][autoscaler-scaler-methods] in the Scaler function page for more information.
-`stepSize`               | 2 or 200       | Number of nodes that should be added or removed when scaling with the `STEPWISE` method.
-`overloadStepSize`       | 5 or 500       | Number of nodes that should be added when the Cloud Spanner instance is overloaded, and the `STEPWISE` method is used.
+`stepSize`               | 2 N or 200 PU  | Number of nodes that should be added or removed when scaling with the `STEPWISE` method.
+`overloadStepSize`       | 5 N or 500 PU  | Number of nodes that should be added when the Cloud Spanner instance is overloaded, and the `STEPWISE` method is used.
 `scaleOutCoolingMinutes` | 5              | Minutes to wait after scaling IN or OUT before a scale OUT event can be processed.
 `scaleInCoolingMinutes`  | 30             | Minutes to wait after scaling IN or OUT before a scale IN event can be processed.
 `overloadCoolingMinutes` | 5              | Minutes to wait after scaling IN or OUT before a scale OUT event can be processed, when the Spanner instance is overloaded. An instance is overloaded if its High Priority CPU utilization is over 90%.
 `stateProjectId`         | `${projectId}` | The project ID where the Autoscaler state will be persisted. By default it is persisted using [Cloud Firestore][cloud-firestore] in the same project as the Spanner instance.
 `metrics`                | Array          | Array of objects that can override the values in the metrics used to decide when the Cloud Spanner instance should be scaled IN or OUT. Refer to the [metrics definition table](#metrics-parameters) to see the fields used for defining metrics.
+`minNodes` (DEPRECATED)  | 1              | DEPRECATED: Minimum number of Cloud Spanner nodes that the instance can be scaled IN to.
+`maxNodes` (DEPRECATED)  | 3              | DEPRECATED: Maximum number of Cloud Spanner nodes that the instance can be scaled OUT to.
 
 ## Metrics parameters
 

--- a/poller/README.md
+++ b/poller/README.md
@@ -74,11 +74,14 @@ instructions on how to change the payload.
 
 Key                      | Default Value  | Description
 ------------------------ | -------------- | -----------
-`minNodes`               | 1              | Minimum number of Cloud Spanner nodes that the instance can be scaled IN to.
-`maxNodes`               | 3              | Maximum number of Cloud Spanner nodes that the instance can be scaled OUT to.
+`units`                  | `NODES`        | Specifies the units that capacity will be measured in `NODES` or `PROCESSING_UNITS`.
+`minSize`                | 1 or 100       | Minimum number of Cloud Spanner nodes or processing units that the instance can be scaled IN to.
+`maxSize`                | 3 or 2000      | Maximum number of Cloud Spanner nodes or processing units that the instance can be scaled OUT to.
+`minNodes`               | 1              | DEPRECATED: Minimum number of Cloud Spanner nodes that the instance can be scaled IN to.
+`maxNodes`               | 3              | DEPRECATED: Maximum number of Cloud Spanner nodes that the instance can be scaled OUT to.
 `scalingMethod`          | `STEPWISE`     | Scaling method that should be used. Options are: `STEPWISE`, `LINEAR`, `DIRECT`. See the [scaling methods section][autoscaler-scaler-methods] in the Scaler function page for more information.
-`stepSize`               | 2              | Number of nodes that should be added or removed when scaling with the `STEPWISE` method.
-`overloadStepSize`       | 5              | Number of nodes that should be added when the Cloud Spanner instance is overloaded, and the `STEPWISE` method is used.
+`stepSize`               | 2 or 200       | Number of nodes that should be added or removed when scaling with the `STEPWISE` method.
+`overloadStepSize`       | 5 or 500       | Number of nodes that should be added when the Cloud Spanner instance is overloaded, and the `STEPWISE` method is used.
 `scaleOutCoolingMinutes` | 5              | Minutes to wait after scaling IN or OUT before a scale OUT event can be processed.
 `scaleInCoolingMinutes`  | 30             | Minutes to wait after scaling IN or OUT before a scale IN event can be processed.
 `overloadCoolingMinutes` | 5              | Minutes to wait after scaling IN or OUT before a scale OUT event can be processed, when the Spanner instance is overloaded. An instance is overloaded if its High Priority CPU utilization is over 90%.
@@ -124,8 +127,8 @@ Key                        | Default      | Description
 
 ## Custom metrics, thresholds and margins
 
-The Autoscaler determines the number of nodes to be added or
-substracted to an instance based on the
+The Autoscaler determines the number of nodes or processing units to be added
+or substracted to an instance based on the
 [Spanner recommended thresholds][spanner-metrics] for High Priority CPU, 24 hour
 rolling average CPU and Storage utilization metrics.
 
@@ -181,15 +184,17 @@ and project id.
         "projectId": "basic-configuration",
         "instanceId": "another-spanner1",
         "scalerPubSubTopic": "projects/my-spanner-project/topics/spanner-scaling",
-        "minNodes": 5,
-        "maxNodes": 30,
+        "units": "NODES",
+        "minSize": 5,
+        "maxSize": 30,
         "scalingMethod": "DIRECT"
     },{
         "projectId": "custom-threshold",
         "instanceId": "spanner1",
         "scalerPubSubTopic": "projects/my-spanner-project/topics/spanner-scaling",
-        "minNodes": 1,
-        "maxNodes": 3,
+        "units": "PROCESSING_UNITS",
+        "minSize": 100,
+        "maxSize": 3000,
         "metrics": [
           {
             "name": "high_priority_cpu",
@@ -201,8 +206,9 @@ and project id.
         "projectId": "custom-metric",
         "instanceId": "another-spanner1",
         "scalerPubSubTopic": "projects/my-spanner-project/topics/spanner-scaling",
-        "minNodes": 5,
-        "maxNodes": 30,
+        "units": "NODES",
+        "minSize": 5,
+        "maxSize": 30,
         "scalingMethod": "LINEAR",
         "metrics": [
           {

--- a/poller/index.js
+++ b/poller/index.js
@@ -37,11 +37,9 @@ const nodesDefaults = {
   units: 'NODES',
   minSize: 1,
   maxSize: 3,
-  minNodes: 1,
-  maxNodes: 3,
   stepSize: 2,
   overloadStepSize: 5,
-}
+};
 const processingUnitsDefaults = {
   units: 'PROCESSING_UNITS',
   minSize: 100,
@@ -258,16 +256,15 @@ async function parseAndEnrichPayload(payload) {
       spanners[sIdx] = {...nodesDefaults, ...spanners[sIdx]};
 
       // if minNodes and maxNodes are not default and differ from minSize/maxSize
-      // we need to provide a depercation warning and set minSize/maxSize for to
-      // help the scaler function
+      // provide a deprecation warning and set minSize/maxSize for the scaler function
       if(spanners[sIdx].minNodes && spanners[sIdx].minSize != spanners[sIdx].minNodes) {
-        log('DEPRECATION: minNodes is deprecated. Values will be copied to minSize.',
+        log(`DEPRECATION: minNodes is deprecated, remove minNodes from your config and instead use: units = 'NODES' and minSize = ${spanners[sIdx].minNodes}`,
            'WARNING');
         spanners[sIdx].minSize = spanners[sIdx].minNodes;
       }
 
       if(spanners[sIdx].maxNodes && spanners[sIdx].maxSize != spanners[sIdx].maxNodes) {
-        log('DEPRECATION: maxNodes are deprecated. Values will be copied to maxSize.',
+        log(`DEPRECATION: maxNodes are deprecated, remove maxNodes from your config and instead use: units = 'NODES' and minSize = ${spanners[sIdx].maxNodes}`,
            'WARNING');
         spanners[sIdx].maxSize = spanners[sIdx].maxNodes;
       }

--- a/poller/index.js
+++ b/poller/index.js
@@ -27,20 +27,33 @@ const {Spanner} = require('@google-cloud/spanner');
 // GCP service clients
 const metricsClient = new monitoring.MetricServiceClient();
 const pubSub = new PubSub();
-const spannerDefaults = {
+const baseDefaults = {
+  units: 'NODES',
+  scaleOutCoolingMinutes: 5,
+  scaleInCoolingMinutes: 30,
+  scalingMethod: 'STEPWISE'
+};
+const nodesDefaults = {
+  units: 'NODES',
+  minSize: 1,
+  maxSize: 3,
   minNodes: 1,
   maxNodes: 3,
   stepSize: 2,
   overloadStepSize: 5,
-  scaleOutCoolingMinutes: 5,
-  scaleInCoolingMinutes: 30,
-  scalingMethod: 'STEPWISE'
+}
+const processingUnitsDefaults = {
+  units: 'PROCESSING_UNITS',
+  minSize: 100,
+  maxSize: 2000,
+  stepSize: 200,
+  overloadStepSize: 500
 };
 const metricDefaults = {
   period: 60,
   aligner: 'ALIGN_MAX',
   reducer: 'REDUCE_SUM'
-}
+};
 const DEFAULT_THRESHOLD_MARGIN = 5;
 
 function log(message, severity = 'DEBUG', payload) {
@@ -186,12 +199,14 @@ function getSpannerMetadata(projectId, spannerInstanceId) {
 
   return spannerInstance.getMetadata().then(data => {
     const metadata = data[0];
-    log(`DisplayName: ${metadata['displayName']}`);
-    log(`NodeCount:   ${metadata['nodeCount']}`);
-    log(`Config:      ${metadata['config'].split('/').pop()}`);
+    log(`DisplayName:     ${metadata['displayName']}`);
+    log(`NodeCount:       ${metadata['nodeCount']}`);
+    log(`ProcessingUnits: ${metadata['processingUnits']}`);
+    log(`Config:          ${metadata['config'].split('/').pop()}`);
 
     const spannerMetadata = {
       currentNodes: metadata['nodeCount'],
+      currentProcessingUnits: metadata['processingUnits'],
       regional: metadata['config'].split('/').pop().startsWith('regional')
     };
 
@@ -221,9 +236,46 @@ async function parseAndEnrichPayload(payload) {
   for (var sIdx = 0; sIdx < spanners.length; sIdx++) {
     const metricOverrides = spanners[sIdx].metrics;
 
+    // assemble the config
     // merge in the defaults
-    spanners[sIdx] = {...spannerDefaults, ...spanners[sIdx]};
+    spanners[sIdx] = {...baseDefaults, ...spanners[sIdx]};
 
+    // handle processing units and deprecation of minNodes/maxNodes
+    if(spanners[sIdx].units.toUpperCase() == 'PROCESSING_UNITS') {
+      spanners[sIdx].units = spanners[sIdx].units.toUpperCase();
+      // merge in the processing units defaults
+      spanners[sIdx] = {...processingUnitsDefaults, ...spanners[sIdx]};
+
+      // minNodes and maxNodes should not be used with processing units. If
+      // they are set the config is invalid.
+      if(spanners[sIdx].minNodes || spanners[sIdx].maxNodes ) {
+        throw new Error('INVALID CONFIG: units is set to PROCESSING_UNITS, however, minNodes or maxNodes is set, remove minNodes and maxNodes from your configuration.');
+      }
+    }
+    else if(spanners[sIdx].units.toUpperCase() == 'NODES') {
+      spanners[sIdx].units = spanners[sIdx].units.toUpperCase();
+      // merge in the processing units defaults
+      spanners[sIdx] = {...nodesDefaults, ...spanners[sIdx]};
+
+      // if minNodes and maxNodes are not default and differ from minSize/maxSize
+      // we need to provide a depercation warning and set minSize/maxSize for to
+      // help the scaler function
+      if(spanners[sIdx].minNodes && spanners[sIdx].minSize != spanners[sIdx].minNodes) {
+        log('DEPRECATION: minNodes is deprecated. Values will be copied to minSize.',
+           'WARNING');
+        spanners[sIdx].minSize = spanners[sIdx].minNodes;
+      }
+
+      if(spanners[sIdx].maxNodes && spanners[sIdx].maxSize != spanners[sIdx].maxNodes) {
+        log('DEPRECATION: maxNodes are deprecated. Values will be copied to maxSize.',
+           'WARNING');
+        spanners[sIdx].maxSize = spanners[sIdx].maxNodes;
+      }
+    }
+    else
+      throw new Error(`INVALID CONFIG: ${spanners[sIdx].units} is invalid. Valid values are NODES or PROCESSING_UNITS`);
+
+    // assemble the metrics
     spanners[sIdx].metrics =
       buildMetrics(spanners[sIdx].projectId, spanners[sIdx].instanceId);
     // merge in custom thresholds

--- a/poller/test/index.test.js
+++ b/poller/test/index.test.js
@@ -85,7 +85,6 @@ describe('#parseAndEnrichPayload', () => {
 
         let mergedConfig = await parseAndEnrichPayload(payload);
         (mergedConfig[0].units).should.equal('NODES');
-        (mergedConfig[0].minNodes).should.equal(10);
         (mergedConfig[0].minSize).should.equal(10);
 
         unset();


### PR DESCRIPTION
This change adds support for processing units in the Poller function.

The config defaults the units to `NODES`.  If nodes are provided it merges in settings based around nodes and also copies those values into the new `minSize` and `maxSize`, and logs a deprecation warning. If processing units are provided as the units but the `minNodes` or `maxNodes` are used for the sizing params an error is thrown.