### PR TITLE
Passing in units to the poller picks the correct current sizing value…

### DIFF
--- a/poller/index.js
+++ b/poller/index.js
@@ -187,7 +187,7 @@ function getMaxMetricValue(projectId, spannerInstanceId, metric) {
   });
 }
 
-function getSpannerMetadata(projectId, spannerInstanceId) {
+function getSpannerMetadata(projectId, spannerInstanceId, units) {
   log(`----- ${projectId}/${spannerInstanceId}: Getting Metadata -----`,
       'INFO');
 
@@ -205,7 +205,7 @@ function getSpannerMetadata(projectId, spannerInstanceId) {
     log(`Config:          ${metadata['config'].split('/').pop()}`);
 
     const spannerMetadata = {
-      currentSize: (spanner.units == 'NODES') ? metadata['nodeCount'] : metadata['processingUnits'],
+      currentSize: (units == 'NODES') ? metadata['nodeCount'] : metadata['processingUnits'],
       regional: metadata['config'].split('/').pop().startsWith('regional'),
       // DEPRECATED
       currentNodes: metadata['nodeCount'],
@@ -298,7 +298,7 @@ async function parseAndEnrichPayload(payload) {
     // merge in the current Spanner state
     spanners[sIdx] = {
       ...spanners[sIdx],
-      ...await getSpannerMetadata(spanners[sIdx].projectId, spanners[sIdx].instanceId)
+      ...await getSpannerMetadata(spanners[sIdx].projectId, spanners[sIdx].instanceId, spanners[sIdx].units.toUpperCase())
     };
   }
 


### PR DESCRIPTION
Spanner APIs don't actually tell us what the current units are, so we need to pass the units we want to measure the current size in to the metadata request function.