### PR TITLE
Added option tracking states in spanner

### DIFF
--- a/poller/README.md
+++ b/poller/README.md
@@ -84,7 +84,7 @@ Key                      | Default Value  | Description
 `scaleInCoolingMinutes`  | 30             | Minutes to wait after scaling IN or OUT before a scale IN event can be processed.
 `overloadCoolingMinutes` | 5              | Minutes to wait after scaling IN or OUT before a scale OUT event can be processed, when the Spanner instance is overloaded. An instance is overloaded if its High Priority CPU utilization is over 90%.
 `stateProjectId`         | `${projectId}` | The project ID where the Autoscaler state will be persisted. By default it is persisted using [Cloud Firestore][cloud-firestore] in the same project as the Spanner instance.
-`stateDatabase`          | Object         | An Object that can override the database for managing the state of autoscale. The default database is Firestore. Refer to the [state database](#state-database) to see for the detail.
+`stateDatabase`          | Object         | An Object that can override the database for managing the state of the Autoscaler. The default database is Firestore. Refer to the [state database](#state-database) for details.
 `metrics`                | Array          | Array of objects that can override the values in the metrics used to decide when the Cloud Spanner instance should be scaled IN or OUT. Refer to the [metrics definition table](#metrics-parameters) to see the fields used for defining metrics.
 `minNodes` (DEPRECATED)  | 1              | DEPRECATED: Minimum number of Cloud Spanner nodes that the instance can be scaled IN to.
 `maxNodes` (DEPRECATED)  | 3              | DEPRECATED: Maximum number of Cloud Spanner nodes that the instance can be scaled OUT to.
@@ -180,11 +180,11 @@ and project id.
 ## State Database
 
 The table describes the objects used to specify the database
-for managingthe state of autoscale.
+for managing the state of the Autoscaler.
 
 Key                        | Default      | Description
 -------------------------- | ------------ | -----------
-`name`                     | `firestore`  | Name of the database for managing the state of autoscale. By default, Firestore is used. The currently supported values are `firestore` and `spanner`.
+`name`                     | `firestore`  | Name of the database for managing the state of the Autoscaler. By default, Firestore is used. The currently supported values are `firestore` and `spanner`.
 
 ### State Managing in Cloud Spanner
 

--- a/poller/README.md
+++ b/poller/README.md
@@ -179,7 +179,8 @@ and project id.
 
 ## State Database
 
-The table describes the objects used to specify the database for managing the state of autoscale. 
+The table describes the objects used to specify the database
+for managingthe state of autoscale.
 
 Key                        | Default      | Description
 -------------------------- | ------------ | -----------
@@ -194,10 +195,10 @@ Key                        | Description
 `instanceId`               | The instance id of Cloud Spanner which you want to manage the state.
 `databaseId`               | The database id of Cloud Spanner instance which you want to manage the state.
 
-When using Cloud Spanner to manage the state, 
+When using Cloud Spanner to manage the state,
 a table with the following DDL is created at runtime.
 
-```
+```sql
 CREATE TABLE spannerAutoscaler (
   id STRING(MAX),
   lastScalingTimestamp TIMESTAMP,

--- a/poller/README.md
+++ b/poller/README.md
@@ -84,6 +84,7 @@ Key                      | Default Value  | Description
 `scaleInCoolingMinutes`  | 30             | Minutes to wait after scaling IN or OUT before a scale IN event can be processed.
 `overloadCoolingMinutes` | 5              | Minutes to wait after scaling IN or OUT before a scale OUT event can be processed, when the Spanner instance is overloaded. An instance is overloaded if its High Priority CPU utilization is over 90%.
 `stateProjectId`         | `${projectId}` | The project ID where the Autoscaler state will be persisted. By default it is persisted using [Cloud Firestore][cloud-firestore] in the same project as the Spanner instance.
+`stateDatabase`          | Object         | An Object that can override the database for managing the state of autoscale. The default database is Firestore. Refer to the [state database](#state-database) to see for the detail.
 `metrics`                | Array          | Array of objects that can override the values in the metrics used to decide when the Cloud Spanner instance should be scaled IN or OUT. Refer to the [metrics definition table](#metrics-parameters) to see the fields used for defining metrics.
 `minNodes` (DEPRECATED)  | 1              | DEPRECATED: Minimum number of Cloud Spanner nodes that the instance can be scaled IN to.
 `maxNodes` (DEPRECATED)  | 3              | DEPRECATED: Maximum number of Cloud Spanner nodes that the instance can be scaled OUT to.
@@ -175,6 +176,35 @@ the metric definition.
 should be used when querying for data. The Autoscaler will automatically add
 the filter expressions for [Spanner instance resources, instance id](spanner-filter)
 and project id.
+
+## State Database
+
+The table describes the objects used to specify the database for managing the state of autoscale. 
+
+Key                        | Default      | Description
+-------------------------- | ------------ | -----------
+`name`                     | `firestore`  | Name of the database for managing the state of autoscale. By default, Firestore is used. The currently supported values are `firestore` and `spanner`.
+
+### State Managing in Cloud Spanner
+
+If the value of `name` is `spanner`, the following values are required.
+
+Key                        | Description
+-------------------------- | -----------
+`instanceId`               | The instance id of Cloud Spanner which you want to manage the state.
+`databaseId`               | The database id of Cloud Spanner instance which you want to manage the state.
+
+When using Cloud Spanner to manage the state, 
+a table with the following DDL is created at runtime.
+
+```
+CREATE TABLE spannerAutoscaler (
+  id STRING(MAX),
+  lastScalingTimestamp TIMESTAMP,
+  createdOn TIMESTAMP,
+  updatedOn TIMESTAMP,
+) PRIMARY KEY (id)
+```
 
 ## Example configuration
 

--- a/scaler/state.js
+++ b/scaler/state.js
@@ -98,11 +98,10 @@ class StateSpanner {
     const query = {
       columns: ['lastScalingTimestamp', 'createdOn'],
       keySet: {
-        all: true,
-      },
-      limit: 1,
-    };
-    this.table = await this.getTable();
+        keys: [{values: [{stringValue: this.rowId()}]}]
+      }
+    }
+    this.table = await this.getTable() // make sure the table exists
     const [rows] = await this.table.read(query)
     if (rows.length == 0) {
       this.data = await this.init();
@@ -170,10 +169,14 @@ class StateSpanner {
     return this.spanner.table('spannerAutoscaler');
   }
 
+  rowId() {
+    return `projects/${this.projectId}/instances/${this.instanceId}/databases/${this.databaseId}`;
+  }
+
   async updateState(rowData) {
     const row = JSON.parse(JSON.stringify(rowData));
     // for Centralized or Distributed projects, rows have a unique key.
-    row.id = `projects/${this.projectId}/instances/${this.instanceId}/databases/${this.databaseId}`;
+    row.id = this.rowId();
     // converts TIMESTAMP type columns to ISO format string for registration
     Object.keys(row).forEach(key => {
       if (row[key] instanceof Date) {

--- a/scaler/state.js
+++ b/scaler/state.js
@@ -17,16 +17,193 @@
  *
  * By default, this implementation uses a Firestore instance in the same
  * project as the Spanner instance. To use a different project, set the
- * `stateProjectId` parameter in the Cloud Scheduler configuration
+ * `stateProjectId` parameter in the Cloud Scheduler configuration.
+ * 
+ * To use another database to save autoscaler state, set the 
+ * `stateDatabase.name` parameter in the Cloud Scheduler configuration.
+ * The default database is Firestore.
  */
 
 const {Firestore} = require('@google-cloud/firestore');
+const {Spanner} = require('@google-cloud/spanner');
 
 class State {
+  constructor(spanner) {
+    switch (spanner.stateDatabase && spanner.stateDatabase.name) {
+      case 'firestore':
+        this.state = new StateFirestore(spanner);
+        break;
+      case 'spanner':
+        this.state = new StateSpanner(spanner);
+        break;
+      default:
+        this.state = new StateFirestore(spanner);
+        break;
+    }
+  }
+
+  async init() {
+    return await this.state.init();
+  }
+
+  async get() {
+    return await this.state.get();
+  }
+
+  async set() {
+    await this.state.set();
+  }
+
+  get now() {
+    return this.state.now;
+  }
+}
+module.exports = State;
+
+/*
+ * Manages the Autoscaler persistent state in spanner.
+ * 
+ * To manage the Autoscaler state in a spanner database,
+ * set the `stateDatabase.name` parameter to 'spanner' in the Cloud Scheduler configuration.
+ * The following is an example.
+ * 
+ * {
+ *   "stateDatabase": {
+ *       "name":       "spanner",
+ *       "instanceId": "autoscale-test", // your instance id
+ *       "databaseId": "my-database"     // your database id
+ *   }
+ * }
+ */
+class StateSpanner {
+  constructor(spanner) {
+    this.projectId = (spanner.stateProjectId != null) ? spanner.stateProjectId :
+                                                        spanner.projectId;
+    this.instanceId = spanner.stateDatabase.instanceId;
+    this.databaseId = spanner.stateDatabase.databaseId;
+    const s = new Spanner({projectId: this.projectId});
+    this.spanner = s.instance(this.instanceId).database(this.databaseId);
+  }
+
+  async init() {
+    var initData = {
+      lastScalingTimestamp: Spanner.timestamp(new Date(0)),
+      createdOn: Spanner.timestamp(Date.now()),
+    };
+    this.updateState(initData);
+    return initData;
+  }
+
+  async get() {
+    const query = {
+      columns: ['lastScalingTimestamp', 'createdOn'],
+      keySet: {
+        all: true,
+      },
+      limit: 1,
+    };
+    this.table = await this.getTable();
+    const [rows] = await this.table.read(query)
+    if (rows.length == 0) {
+      this.data = await this.init();
+    } else {
+      this.data = rows[0].toJSON();
+    }
+    return this.toMillis(this.data);
+  }
+
+  async set() {
+    await this.get();  // make sure doc exists
+
+    var newData = {
+      updatedOn: Spanner.timestamp(Date.now())
+    };
+    newData.lastScalingTimestamp = Spanner.timestamp(Date.now());
+    await this.updateState(newData);
+  }
+
+  /**
+   * Converts row data from Spanner.timestamp (implementation detail)
+   * to standard JS timestamps, which are number of milliseconds since Epoch
+   */
+  toMillis(rowData) {
+    Object.keys(rowData).forEach(key => {
+      if (rowData[key] instanceof Date) {
+          rowData[key] = rowData[key].getTime();
+      }
+    })
+    return rowData;
+  }
+
+  get now() {
+    return Date.now();
+  }
+
+  async checkIfTableExists() {
+    return await this.spanner.getSchema().then(function(data) {
+      const statements = data[0];
+      const matcher = new RegExp(/CREATE TABLE spannerAutoScaler \(/, 'i');
+      const matches = statements.filter(function (statement) {
+          return matcher.test(statement);
+      });
+      return matches.length == 1;
+    }).catch(function(err) {
+      return false;
+    });
+  }
+
+  async createTable() {
+    const request = [`CREATE TABLE spannerAutoscaler (
+      id STRING(MAX),
+      lastScalingTimestamp TIMESTAMP,
+      createdOn TIMESTAMP,
+      updatedOn TIMESTAMP,
+    ) PRIMARY KEY (id)`];
+    const [operation] = await this.spanner.updateSchema(request);
+    await operation.promise();
+  }
+
+  async getTable() {
+    if (!await this.checkIfTableExists()) {
+      await this.createTable(); // make sure the state table exists
+    }
+    return this.spanner.table('spannerAutoscaler');
+  }
+
+  async updateState(rowData) {
+    const row = JSON.parse(JSON.stringify(rowData));
+    // for Centralized or Distributed projects, rows have a unique key.
+    row.id = `projects/${this.projectId}/instances/${this.instanceId}/databases/${this.databaseId}`;
+    // converts TIMESTAMP type columns to ISO format string for registration
+    Object.keys(row).forEach(key => {
+      if (row[key] instanceof Date) {
+        row[key] = row[key].toISOString();
+      }
+    });
+    this.table.upsert(row);
+  }
+}
+
+/*
+ * Manages the Autoscaler persistent state in firestore.
+ * 
+ * The default database for state management is firestore.
+ * It is also possible to manage with firestore 
+ * by explicitly setting `stateDatabase.name` to 'firestore'.
+ * The following is an example.
+ * 
+ * {
+ *   "stateDatabase": {
+ *       "name": "firestore"
+ *   }
+ * }
+ */
+class StateFirestore {
   constructor(spanner) {
     this.projectId = (spanner.stateProjectId != null) ? spanner.stateProjectId :
                                                         spanner.projectId;
     this.instanceId = spanner.instanceId;
+    this.firestore = new Firestore({projectId: this.projectId})
   }
 
   get docRef() {
@@ -41,7 +218,7 @@ class State {
   /**
    * Converts document data from Firestore.Timestamp (implementation detail)
    * to standard JS timestamps, which are number of milliseconds since Epoch
-   * https://googleapis.dev/nodejs/firestore/latest/Timestamp.htmlr
+   * https://googleapis.dev/nodejs/firestore/latest/Timestamp.html
    */
   toMillis(docData) {
     Object.keys(docData).forEach(key => {
@@ -87,5 +264,3 @@ class State {
     return Firestore.Timestamp.now().toMillis();
   }
 }
-
-module.exports = State;

--- a/terraform/distributed/README.md
+++ b/terraform/distributed/README.md
@@ -184,6 +184,10 @@ Autoscaler infrastructure, with the exception of Cloud Scheduler, lives.
     gcloud alpha firestore databases create --region="${AUTOSCALER_APP_ENGINE_LOCATION}"
     ```
 
+    Alternatively, if you want to use your own spanner to manage
+    the state of autoscale, skip this step
+    and perform step 4 in [Deploying the Autoscaler](#Deploy-the-Application-infrastructure).
+
 ### Deploy the Autoscaler
 
 1.  Set the project ID, region, zone and App Engine location in the
@@ -327,14 +331,26 @@ topic and function in the project where the Spanner instances live.
     Terraform, see
     [Import your Spanner instances](../per-project/README.md#import-your-spanner-instances)
 
-4.  Change directory into the Terraform app-project directory and initialize it.
+4. If you want to manage the state of autoscale in your own Spanner instance,
+   please create the following table in advance.
+
+   ```sql
+   CREATE TABLE spannerAutoscaler (
+      id STRING(MAX),
+      lastScalingTimestamp TIMESTAMP,
+      createdOn TIMESTAMP,
+      updatedOn TIMESTAMP,
+   ) PRIMARY KEY (id)
+   ```
+
+5.  Change directory into the Terraform app-project directory and initialize it.
 
     ```sh
     cd "${APP_DIR}"
     terraform init
     ```
 
-5.  Create the infrastructure in the application project. Answer `yes` when
+6.  Create the infrastructure in the application project. Answer `yes` when
     prompted, after reviewing the resources that Terraform intends to create.
 
     ```sh

--- a/terraform/distributed/README.md
+++ b/terraform/distributed/README.md
@@ -176,16 +176,23 @@ Autoscaler infrastructure, with the exception of Cloud Scheduler, lives.
       --iam-account "terraformer@${AUTOSCALER_PROJECT_ID}.iam.gserviceaccount.com" "${AUTOSCALER_DIR}/key.json"
     ```
 
-9.  If your project does not have a [Firestore][firestore] instance yet, create
-    one
+9. Create a Google App Engine app, to enable the APIs for Cloud Scheduler and Firestore.
 
     ```sh
     gcloud app create --region="${AUTOSCALER_APP_ENGINE_LOCATION}"
+    ```
+
+10. Create database to store the state of the Autoscaler. 
+    State can be stored in either Firestore or Cloud Spanner.
+
+    In case you want to use Firestore, create a new instance
+    if your project does not have yet.
+
+    ```sh
     gcloud alpha firestore databases create --region="${AUTOSCALER_APP_ENGINE_LOCATION}"
     ```
 
-    Alternatively, if you want to use your own spanner to manage
-    the state of autoscale, skip this step
+    In case you want to use Cloud Spanner, skip this step
     and perform step 4 in [Deploying the Autoscaler](#Deploy-the-Application-infrastructure).
 
 ### Deploy the Autoscaler
@@ -331,7 +338,7 @@ topic and function in the project where the Spanner instances live.
     Terraform, see
     [Import your Spanner instances](../per-project/README.md#import-your-spanner-instances)
 
-4. If you want to manage the state of autoscale in your own Spanner instance,
+4. If you want to manage the state of the Autoscaler in your own Cloud Spanner instance,
    please create the following table in advance.
 
    ```sql

--- a/terraform/distributed/README.md
+++ b/terraform/distributed/README.md
@@ -176,24 +176,24 @@ Autoscaler infrastructure, with the exception of Cloud Scheduler, lives.
       --iam-account "terraformer@${AUTOSCALER_PROJECT_ID}.iam.gserviceaccount.com" "${AUTOSCALER_DIR}/key.json"
     ```
 
-9. Create a Google App Engine app, to enable the APIs for Cloud Scheduler and Firestore.
+9.  Create a Google App Engine app, to enable the APIs for Cloud Scheduler and Firestore.
 
     ```sh
     gcloud app create --region="${AUTOSCALER_APP_ENGINE_LOCATION}"
     ```
 
-10. Create database to store the state of the Autoscaler. 
-    State can be stored in either Firestore or Cloud Spanner.
+10.  Create database to store the state of the Autoscaler.
+     State can be stored in either Firestore or Cloud Spanner.
 
-    In case you want to use Firestore, create a new instance
-    if your project does not have yet.
+     In case you want to use Firestore, create a new instance
+     if your project does not have yet.
 
-    ```sh
-    gcloud alpha firestore databases create --region="${AUTOSCALER_APP_ENGINE_LOCATION}"
-    ```
+     ```sh
+     gcloud alpha firestore databases create --region="${AUTOSCALER_APP_ENGINE_LOCATION}"
+     ```
 
-    In case you want to use Cloud Spanner, skip this step
-    and perform step 4 in [Deploying the Autoscaler](#Deploy-the-Application-infrastructure).
+     In case you want to use Cloud Spanner, skip this step
+     and perform step 4 in [Deploying the Autoscaler](#Deploy-the-Application-infrastructure).
 
 ### Deploy the Autoscaler
 
@@ -338,17 +338,17 @@ topic and function in the project where the Spanner instances live.
     Terraform, see
     [Import your Spanner instances](../per-project/README.md#import-your-spanner-instances)
 
-4. If you want to manage the state of the Autoscaler in your own Cloud Spanner instance,
-   please create the following table in advance.
+4.  If you want to manage the state of the Autoscaler in your own Cloud Spanner instance,
+    please create the following table in advance.
 
-   ```sql
-   CREATE TABLE spannerAutoscaler (
-      id STRING(MAX),
-      lastScalingTimestamp TIMESTAMP,
-      createdOn TIMESTAMP,
-      updatedOn TIMESTAMP,
-   ) PRIMARY KEY (id)
-   ```
+    ```sql
+    CREATE TABLE spannerAutoscaler (
+       id STRING(MAX),
+       lastScalingTimestamp TIMESTAMP,
+       createdOn TIMESTAMP,
+       updatedOn TIMESTAMP,
+    ) PRIMARY KEY (id)
+    ```
 
 5.  Change directory into the Terraform app-project directory and initialize it.
 

--- a/terraform/per-project/README.md
+++ b/terraform/per-project/README.md
@@ -170,24 +170,25 @@ In this section you prepare your project for deployment.
       --iam-account "terraformer@${PROJECT_ID}.iam.gserviceaccount.com" "${AUTOSCALER_DIR}/key.json"
     ```
 
-9. Create a Google App Engine app, to enable the APIs for Cloud Scheduler and Firestore.
+9.  Create a Google App Engine app, to enable the APIs
+    for Cloud Scheduler and Firestore
 
     ```sh
     gcloud app create --region="${AUTOSCALER_APP_ENGINE_LOCATION}"
     ```
 
-10. Create database to store the state of the Autoscaler. 
-    State can be stored in either Firestore or Cloud Spanner.
+10.  Create database to store the state of the Autoscaler.
+     State can be stored in either Firestore or Cloud Spanner.
 
-    In case you want to use Firestore, create a new instance
-    if your project does not have yet.
+     In case you want to use Firestore, create a new instance
+     if your project does not have yet.
 
-    ```sh
-    gcloud alpha firestore databases create --region="${AUTOSCALER_APP_ENGINE_LOCATION}"
-    ```
+     ```sh
+     gcloud alpha firestore databases create --region="${AUTOSCALER_APP_ENGINE_LOCATION}"
+     ```
 
-    In case you want to use Cloud Spanner, skip this step
-    and perform step 4 in [Deploying the Autoscaler](#Deploy-the-Application-infrastructure).
+     In case you want to use Cloud Spanner, skip this step
+     and perform step 4 in [Deploying the Autoscaler](#Deploy-the-Application-infrastructure).
 
 ## Deploying the Autoscaler
 
@@ -219,17 +220,17 @@ In this section you prepare your project for deployment.
     For more information on how to make your Spanner instance to be managed by
     Terraform, see [Import your Spanner instances](#import-your-spanner-instances)
 
-3. If you want to manage the state of the Autoscaler in your own Cloud Spanner instance,
-   please create the following table in advance.
+3.  If you want to manage the state of the Autoscaler in your own Cloud Spanner instance,
+    please create the following table in advance.
 
-   ```sql
-   CREATE TABLE spannerAutoscaler (
-      id STRING(MAX),
-      lastScalingTimestamp TIMESTAMP,
-      createdOn TIMESTAMP,
-      updatedOn TIMESTAMP,
-   ) PRIMARY KEY (id)
-   ```
+    ```sql
+    CREATE TABLE spannerAutoscaler (
+       id STRING(MAX),
+       lastScalingTimestamp TIMESTAMP,
+       createdOn TIMESTAMP,
+       updatedOn TIMESTAMP,
+    ) PRIMARY KEY (id)
+    ```
 
 4.  Change directory into the Terraform per-project directory and initialize it.
 

--- a/terraform/per-project/README.md
+++ b/terraform/per-project/README.md
@@ -170,17 +170,24 @@ In this section you prepare your project for deployment.
       --iam-account "terraformer@${PROJECT_ID}.iam.gserviceaccount.com" "${AUTOSCALER_DIR}/key.json"
     ```
 
-9.  If your project does not have a [Firestore][firestore] instance yet, create
-    one
+9. Create a Google App Engine app, to enable the APIs for Cloud Scheduler and Firestore.
 
     ```sh
-    gcloud app create --region="${APP_ENGINE_LOCATION}"
-    gcloud alpha firestore databases create --region="${APP_ENGINE_LOCATION}"
+    gcloud app create --region="${AUTOSCALER_APP_ENGINE_LOCATION}"
     ```
 
-    Alternatively, if you want to use your own spanner to manage
-    the state of autoscale, skip this step
-    and perform step 3 in [Deploying the Autoscaler](#Deploying-the-Autoscaler).
+10. Create database to store the state of the Autoscaler. 
+    State can be stored in either Firestore or Cloud Spanner.
+
+    In case you want to use Firestore, create a new instance
+    if your project does not have yet.
+
+    ```sh
+    gcloud alpha firestore databases create --region="${AUTOSCALER_APP_ENGINE_LOCATION}"
+    ```
+
+    In case you want to use Cloud Spanner, skip this step
+    and perform step 4 in [Deploying the Autoscaler](#Deploy-the-Application-infrastructure).
 
 ## Deploying the Autoscaler
 
@@ -212,7 +219,7 @@ In this section you prepare your project for deployment.
     For more information on how to make your Spanner instance to be managed by
     Terraform, see [Import your Spanner instances](#import-your-spanner-instances)
 
-3. If you want to manage the state of autoscale in your own Spanner instance,
+3. If you want to manage the state of the Autoscaler in your own Cloud Spanner instance,
    please create the following table in advance.
 
    ```sql

--- a/terraform/per-project/README.md
+++ b/terraform/per-project/README.md
@@ -178,6 +178,10 @@ In this section you prepare your project for deployment.
     gcloud alpha firestore databases create --region="${APP_ENGINE_LOCATION}"
     ```
 
+    Alternatively, if you want to use your own spanner to manage
+    the state of autoscale, skip this step
+    and perform step 3 in [Deploying the Autoscaler](#Deploying-the-Autoscaler).
+
 ## Deploying the Autoscaler
 
 1.  Set the project ID, region and zone in the corresponding Terraform
@@ -208,20 +212,32 @@ In this section you prepare your project for deployment.
     For more information on how to make your Spanner instance to be managed by
     Terraform, see [Import your Spanner instances](#import-your-spanner-instances)
 
-3.  Change directory into the Terraform per-project directory and initialize it.
+3. If you want to manage the state of autoscale in your own Spanner instance,
+   please create the following table in advance.
+
+   ```sql
+   CREATE TABLE spannerAutoscaler (
+      id STRING(MAX),
+      lastScalingTimestamp TIMESTAMP,
+      createdOn TIMESTAMP,
+      updatedOn TIMESTAMP,
+   ) PRIMARY KEY (id)
+   ```
+
+4.  Change directory into the Terraform per-project directory and initialize it.
 
     ```sh
     cd "${AUTOSCALER_DIR}"
     terraform init
     ```
 
-4.  Import the existing AppEngine application into Terraform state
+5.  Import the existing AppEngine application into Terraform state
 
     ```sh
     terraform import module.scheduler.google_app_engine_application.app "${PROJECT_ID}"
     ```
 
-5.  Create the Autoscaler infrastructure. Answer `yes` when prompted, after
+6.  Create the Autoscaler infrastructure. Answer `yes` when prompted, after
     reviewing the resources that Terraform intends to create.
 
     ```sh


### PR DESCRIPTION
When Firestore is Datastore mode, currently the autoscaler is not able to use,
so I added an option tracking states in spanner.

Refer to #2