### PR TITLE
Remove dashboard variables without default from root modules

### DIFF
--- a/poller/package.json
+++ b/poller/package.json
@@ -4,23 +4,23 @@
     "license": "Apache-2.0",
     "author": "Google Inc.",
     "dependencies": {
-      "@google-cloud/functions-framework": "^2.0.0",
+      "@google-cloud/functions-framework": "^3.0.0",
         "@google-cloud/monitoring": "^2.3.4",
         "@google-cloud/pubsub": "^2.16.6",
         "@google-cloud/spanner": "^5.13.1"
     },
     "scripts": {
         "start": "functions-framework --target=checkSpannerScaleMetricsHTTP",
-        "debug": "node --inspect node_modules/@google-cloud/functions-framework --target=checkSpannerScaleMetricsHTTP",
+        "debug": "node --inspect node_modules/.bin/functions-framework --target=checkSpannerScaleMetricsHTTP",
         "test": "nyc --reporter=text mocha --recursive --require mocha-suppress-logs",
         "mdlint": "cd .. && markdownlint '**/*.md' --config .mdl.json --ignore '**/node_modules/**' --ignore 'code-of-conduct.md'"
     },
     "devDependencies": {
-        "markdownlint": "^0.23.1",
+        "markdownlint": "^0.25.1",
         "mocha": "^9.0.3",
         "mocha-suppress-logs": "^0.3.1",
         "nyc": "^15.1.0",
-        "rewire": "^5.0.0",
+        "rewire": "^6.0.0",
         "should": "^13.2.3",
         "sinon": "^11.1.2"
     }

--- a/scaler/package.json
+++ b/scaler/package.json
@@ -5,22 +5,22 @@
   "author": "Google Inc.",
   "dependencies": {
     "@google-cloud/firestore": "^4.14.1",
-    "@google-cloud/functions-framework": "^2.0.0",
+    "@google-cloud/functions-framework": "^3.0.0",
     "@google-cloud/spanner": "^5.13.1"
   },
   "scripts": {
     "start": "functions-framework --target=scaleSpannerInstanceHTTP --port=8081",
-    "debug": "node --inspect node_modules/@google-cloud/functions-framework --target=scaleSpannerInstanceHTTP --port=8081",
+    "debug": "node --inspect node_modules/.bin/functions-framework --target=scaleSpannerInstanceHTTP --port=8081",
     "test": "nyc --reporter=text mocha --recursive --require mocha-suppress-logs",
     "mdlint": "cd .. && markdownlint '**/*.md' --config .mdl.json --ignore '**/node_modules/**' --ignore 'code-of-conduct.md'"
   },
   "devDependencies": {
     "@sinonjs/referee": "^9.1.1",
-    "markdownlint": "^0.23.0",
+    "markdownlint": "^0.25.0",
     "mocha": "^9.0.3",
     "mocha-suppress-logs": "^0.3.1",
     "nyc": "^15.1.0",
-    "rewire": "^5.0.0",
+    "rewire": "^6.0.0",
     "should": "^13.2.3",
     "sinon": "^11.1.2"
   }

--- a/terraform/distributed/app-project/main.tf
+++ b/terraform/distributed/app-project/main.tf
@@ -77,7 +77,4 @@ module "monitoring" {
   source  = "../modules/monitoring"
 
   project_id                                       = var.project_id
-  dashboard_threshold_high_priority_cpu_percentage = var.dashboard_threshold_high_priority_cpu_percentage
-  dashboard_threshold_rolling_24_hr_percentage     = var.dashboard_threshold_rolling_24_hr_percentage
-  dashboard_threshold_storage_percentage           = var.dashboard_threshold_storage_percentage
 }

--- a/terraform/distributed/app-project/variables.tf
+++ b/terraform/distributed/app-project/variables.tf
@@ -53,18 +53,3 @@ variable "terraform_dashboard" {
   type        = bool
   default     = true
 }
-
-variable "dashboard_threshold_high_priority_cpu_percentage" {
-  description = "Threshold value related to the High Priority CPU utilization."
-  type        = number
-}
-
-variable "dashboard_threshold_rolling_24_hr_percentage" {
-  description = "Threshold value related to the Rolling(Smoothed) 24 hours CPU utilization."
-  type        = number
-}
-
-variable "dashboard_threshold_storage_percentage" {
-  description = "Threshold value related to the Storage utilization."
-  type        = number
-}

--- a/terraform/distributed/autoscaler-project/main.tf
+++ b/terraform/distributed/autoscaler-project/main.tf
@@ -58,7 +58,4 @@ module "monitoring" {
   source  = "../modules/monitoring"
 
   project_id                                       = var.project_id
-  dashboard_threshold_high_priority_cpu_percentage = var.dashboard_threshold_high_priority_cpu_percentage
-  dashboard_threshold_rolling_24_hr_percentage     = var.dashboard_threshold_rolling_24_hr_percentage
-  dashboard_threshold_storage_percentage           = var.dashboard_threshold_storage_percentage
 }

--- a/terraform/distributed/autoscaler-project/variables.tf
+++ b/terraform/distributed/autoscaler-project/variables.tf
@@ -44,18 +44,3 @@ variable "terraform_dashboard" {
   type        = bool
   default     = true
 }
-
-variable "dashboard_threshold_high_priority_cpu_percentage" {
-  description = "Threshold value related to the High Priority CPU utilization."
-  type        = number
-}
-
-variable "dashboard_threshold_rolling_24_hr_percentage" {
-  description = "Threshold value related to the Rolling(Smoothed) 24 hours CPU utilization."
-  type        = number
-}
-
-variable "dashboard_threshold_storage_percentage" {
-  description = "Threshold value related to the Storage utilization."
-  type        = number
-}

--- a/terraform/per-project/README.md
+++ b/terraform/per-project/README.md
@@ -176,7 +176,7 @@ In this section you prepare your project for deployment.
     for Cloud Scheduler and Firestore
 
     ```sh
-    gcloud app create --region="${AUTOSCALER_APP_ENGINE_LOCATION}"
+    gcloud app create --region="${APP_ENGINE_LOCATION}"
     ```
 
 10.  Create database to store the state of the Autoscaler.
@@ -186,7 +186,7 @@ In this section you prepare your project for deployment.
      if your project does not have yet.
 
      ```sh
-     gcloud alpha firestore databases create --region="${AUTOSCALER_APP_ENGINE_LOCATION}"
+     gcloud alpha firestore databases create --region="${APP_ENGINE_LOCATION}"
      ```
 
      In case you want to use Cloud Spanner, skip this step

--- a/terraform/per-project/main.tf
+++ b/terraform/per-project/main.tf
@@ -67,7 +67,4 @@ module "monitoring" {
   source  = "../modules/monitoring"
 
   project_id                                       = var.project_id
-  dashboard_threshold_high_priority_cpu_percentage = var.dashboard_threshold_high_priority_cpu_percentage
-  dashboard_threshold_rolling_24_hr_percentage     = var.dashboard_threshold_rolling_24_hr_percentage
-  dashboard_threshold_storage_percentage           = var.dashboard_threshold_storage_percentage
 }

--- a/terraform/per-project/variables.tf
+++ b/terraform/per-project/variables.tf
@@ -56,21 +56,6 @@ variable "terraform_dashboard" {
   default     = true
 }
 
-variable "dashboard_threshold_high_priority_cpu_percentage" {
-  description = "Threshold value related to the High Priority CPU utilization."
-  type        = number
-}
-
-variable "dashboard_threshold_rolling_24_hr_percentage" {
-  description = "Threshold value related to the Rolling(Smoothed) 24 hours CPU utilization."
-  type        = number
-}
-
-variable "dashboard_threshold_storage_percentage" {
-  description = "Threshold value related to the Storage utilization."
-  type        = number
-}
-
 locals {
   # By default, these config files produce a per-project deployment
   # If you want a centralized deployment instead, then specify 


### PR DESCRIPTION
Fix for issue #65 : 
Removed the following variables from the root terraform modules for the distributed and per-project deployments:

* dashboard_threshold_high_priority_cpu_percentage
* dashboard_threshold_rolling_24_hr_percentage
* dashboard_threshold_storage_percentage

A user can modify the defaults directly in the monitoring module, or pass the values by modifying the root module.  