### PR TITLE
Scale in limiter

### DIFF
--- a/scaler/scaling-methods/linear.js
+++ b/scaler/scaling-methods/linear.js
@@ -27,7 +27,15 @@ const {maybeRound} = require('../utils.js');
 function calculateSize(spanner) {
   return baseModule.loopThroughSpannerMetrics(spanner, (spanner, metric) => {
     if (baseModule.metricValueWithinRange(metric)) return spanner.currentSize;
-    else return maybeRound(Math.ceil(spanner.currentSize * metric.value / metric.threshold), spanner.units, metric.name);
+    else {
+      var suggestedSize = Math.ceil(spanner.currentSize * metric.value / metric.threshold)
+      
+      if (suggestedSize < spanner.currentSize && spanner.scaleInLimit) {
+        const limit = spanner.currentSize * spanner.scaleInLimit
+        suggestedSize = Math.max(suggestedSize, spanner.currentSize - limit)
+      }
+      return maybeRound(suggestedSize, spanner.units, metric.name);
+    }
   });
 }
 

--- a/scaler/test/scaling-methods/linear.test.js
+++ b/scaler/test/scaling-methods/linear.test.js
@@ -76,4 +76,27 @@ describe('#linear.calculateSize', () => {
     assert.equals(callbackStub.callCount, 1);
   });
   
+  it('should return the higher instance size if a scaleInLimit is specified', () => {
+    const spanner = createSpannerParameters({units : 'NODES', currentSize: 20, scaleInLimit: .1}, true);
+    const callbackStub = stubBaseModule(spanner, {value : 30, threshold : 65}, false);
+
+    calculateSize(spanner).should.equal(18);
+    assert.equals(callbackStub.callCount, 1);
+  });
+
+  it('should scaleIn even when a scaleInLimit is not specified', () => {
+    const spanner = createSpannerParameters({units : 'NODES', currentSize: 20}, true);
+    const callbackStub = stubBaseModule(spanner, {value : 30, threshold : 65}, false);
+
+    calculateSize(spanner).should.equal(10);
+    assert.equals(callbackStub.callCount, 1);
+  });
+
+  it('should ignore scaleInLimit when scaling out', () => {
+    const spanner = createSpannerParameters({units : 'NODES', currentSize: 20, scaleInLimit: .1}, true);
+    const callbackStub = stubBaseModule(spanner, {value : 80, threshold : 65}, false);
+
+    calculateSize(spanner).should.equal(25);
+    assert.equals(callbackStub.callCount, 1);
+  });
 });


### PR DESCRIPTION
When using the linear algorithm and scaling in, you might not want to take large steps as it relates to the overall size of the Cloud Spanner instance. This pull request adds a new optional parameter `scaleInLimit` which is a decimal value. This is the maximum percentage of the Spanner instance that can be scaled in a given scaling event.

For example if the Spanner instance is current 20 nodes and the scaleInLimit is .1 the maximum number of nodes that can be scaled in is 2 nodes.