### PR TITLE
Update Google Cloud autoscaler to use templatefile built in function

### DIFF
--- a/terraform/modules/monitoring/main.tf
+++ b/terraform/modules/monitoring/main.tf
@@ -16,15 +16,11 @@
 
 resource "google_monitoring_dashboard" "dashboard" {
   project        = var.project_id
-  dashboard_json = data.template_file.spanner_dashboard.rendered
-}
-
-data "template_file" "spanner_dashboard" {
-  template = file("${path.module}/dashboard.tpl.json")
-  vars = {
-      // refer to https://cloud.google.com/spanner/docs/monitoring-cloud#high-priority-cpu
-      thresholds_high_priority_cpu_percentage = var.dashboard_threshold_high_priority_cpu_percentage
-      thresholds_rolling_24hr_cpu_percentage  = var.dashboard_threshold_rolling_24_hr_percentage
-      thresholds_storage_percentage           = var.dashboard_threshold_storage_percentage
-  }
+  dashboard_json = templatefile("${path.module}/dashboard.tpl.json",
+  {
+    // refer to https://cloud.google.com/spanner/docs/monitoring-cloud#high-priority-cpu
+    thresholds_high_priority_cpu_percentage = var.dashboard_threshold_high_priority_cpu_percentage
+    thresholds_rolling_24hr_cpu_percentage  = var.dashboard_threshold_rolling_24_hr_percentage
+    thresholds_storage_percentage           = var.dashboard_threshold_storage_percentage
+  })
 }

--- a/terraform/per-project/main.tf
+++ b/terraform/per-project/main.tf
@@ -15,6 +15,8 @@
  */
 
 terraform {
+  required_version = ">= 0.12.0"
+
   required_providers {
     google = {
       version = ">3.5.0"


### PR DESCRIPTION
Currently the autoscaler terraform fails to init on M1 Macs because of this issue: https://discuss.hashicorp.com/t/template-v2-2-0-does-not-have-a-package-available-mac-m1/35099 as the template_file provider is deprecated.