### PR TITLE
Add troubleshooting guidance for common issues

### DIFF
--- a/terraform/gke/README.md
+++ b/terraform/gke/README.md
@@ -235,6 +235,10 @@ In this section you prepare your project for deployment.
     gcloud firestore databases create --region="${APP_ENGINE_LOCATION}"
     ```
 
+    You will also need to make a minor modification to the Autoscaler
+    configuration. The required steps to do this are later in these
+    instructions.
+
 5.  Next, continue to [Deploying the Autoscaler](#deploying-the-autoscaler)
 
 ## Using Spanner for Autoscaler state
@@ -402,15 +406,23 @@ similar process.
     schema of the configuration, see the
     [Poller configuration][autoscaler-config-params] section.
 
-    If you have chosen to use Firestore to hold the Autoscaler state as described
-    above, edit the file and remove the following lines:
+9.  If you have chosen to use Firestore to hold the Autoscaler state as described
+    above, edit the above file, and remove the following lines:
 
-    ```
+    ```yaml
      stateDatabase:
        name: spanner
        instanceId: autoscale-test
        databaseId: spanner-autoscaler-state
     ```
+
+    **Note:** If you do not remove these lines, the Autoscaler will attempt to
+    use the above non-existent Spanner database for its state store, which will
+    result in the Poller component failing to start. Please see the
+    [Troubleshooting](#troubleshooting) section for more details.
+
+    If you have chosen to use your own Spanner instance, please edit the above
+    configuration file accordingly.
 
 9.  To configure the Autoscaler and begin scaling operations, run the following
     command:
@@ -419,11 +431,44 @@ similar process.
     kubectl apply -f autoscaler-config/autoscaler-config.yaml
     ```
 
-10.  Any changes made to the configuration file and applied with `kubectl
-     apply` will update the autoscaler configuration.
+10. Any changes made to the configuration file and applied with `kubectl
+    apply` will update the Autoscaler configuration.
 
-11.  You can view logs for the Autoscaler components via `kubectl` or the [Cloud
-     Logging][cloud-console-logging] interface in the Google Cloud console.
+11. You can view logs for the Autoscaler components via `kubectl` or the [Cloud
+    Logging][cloud-console-logging] interface in the Google Cloud console.
+
+## Troubleshooting
+
+This section contains guidance on what to do if you encounter issues when
+following the instructions above.
+
+### If the GKE cluster is not successfully created
+
+1.  Check there are no [Organizational Policy][organizational-policy] rules that may conflict with cluster creation.
+
+### If the Poller fails to run successfully
+
+1.  If you have chosen to use Firestore for Autoscaler state and you see the following error in the logs:
+
+    ```sh
+     Error: 5 NOT_FOUND: Database not found: projects/<YOUR_PROJECT>/instances/autoscale-test/databases/spanner-autoscaler-state
+    ```
+
+    Edit the file `${AUTOSCALER_ROOT}/autoscaler-config/autoscaler-config.yaml`
+    and remove the following stanza:
+
+    ```yaml
+     stateDatabase:
+       name: spanner
+       instanceId: autoscale-test
+       databaseId: spanner-autoscaler-state
+    ```
+
+2.  Check the formatting of the YAML configration file:
+
+    ```sh
+    cat ${AUTOSCALER_ROOT}/autoscaler-config/autoscaler-config.yaml
+    ```
 
 <!-- LINKS: https://www.markdownguide.org/basic-syntax/#reference-style-links -->
 [autoscaler-poller]: ../../poller/README.md
@@ -451,3 +496,4 @@ similar process.
 [terraform-spanner-instance]: https://www.terraform.io/docs/providers/google/r/spanner_instance.html
 [terraform-spanner-db]: https://www.terraform.io/docs/providers/google/r/spanner_database.html
 [provider-issue]: https://github.com/hashicorp/terraform-provider-google/issues/6782
+[organizational-policy]: https://cloud.google.com/resource-manager/docs/organization-policy/overview

--- a/terraform/gke/README.md
+++ b/terraform/gke/README.md
@@ -424,18 +424,18 @@ similar process.
     If you have chosen to use your own Spanner instance, please edit the above
     configuration file accordingly.
 
-9.  To configure the Autoscaler and begin scaling operations, run the following
-    command:
+10.  To configure the Autoscaler and begin scaling operations, run the following
+     command:
 
-    ```sh
-    kubectl apply -f autoscaler-config/autoscaler-config.yaml
-    ```
+     ```sh
+     kubectl apply -f autoscaler-config/autoscaler-config.yaml
+     ```
 
-10. Any changes made to the configuration file and applied with `kubectl
-    apply` will update the Autoscaler configuration.
+11.  Any changes made to the configuration file and applied with `kubectl
+     apply` will update the Autoscaler configuration.
 
-11. You can view logs for the Autoscaler components via `kubectl` or the [Cloud
-    Logging][cloud-console-logging] interface in the Google Cloud console.
+12.  You can view logs for the Autoscaler components via `kubectl` or the [Cloud
+     Logging][cloud-console-logging] interface in the Google Cloud console.
 
 ## Troubleshooting
 
@@ -444,11 +444,13 @@ following the instructions above.
 
 ### If the GKE cluster is not successfully created
 
-1.  Check there are no [Organizational Policy][organizational-policy] rules that may conflict with cluster creation.
+1.  Check there are no [Organizational Policy][organizational-policy] rules
+    that may conflict with cluster creation.
 
 ### If the Poller fails to run successfully
 
-1.  If you have chosen to use Firestore for Autoscaler state and you see the following error in the logs:
+1.  If you have chosen to use Firestore for Autoscaler state and you see the
+    following error in the logs:
 
     ```sh
      Error: 5 NOT_FOUND: Database not found: projects/<YOUR_PROJECT>/instances/autoscale-test/databases/spanner-autoscaler-state


### PR DESCRIPTION
This adds to the GKE documentation with a short `Troubleshooting` section for common issues, and an additional note on the extra configuration step if using Firebase.