### PR TITLE
Expose Cloud monitoring secondary aggregation to poller configuration

### DIFF
--- a/poller/README.md
+++ b/poller/README.md
@@ -133,6 +133,10 @@ Key                        | Default      | Description
 `reducer`                  | `REDUCE_SUM` | The reducer specifies how the data points should be aggregated when querying for metrics, typically `REDUCE_SUM`. For more details please refer to [Alert Policies - Reducer][alertpolicy-reducer] documentation.
 `aligner`                  | `ALIGN_MAX`  | The aligner specifies how the data points should be aligned in the time series, typically `ALIGN_MAX`. For more details please refer to [Alert Policies - Aligner][alertpolicy-aligner] documentation.
 `period`                   | 60           | Defines the period of time in units of seconds at which aggregation takes place. Typically the period should be 60.
+`groupByFields`            | []           | An array that defines fields to aggregate over for primary aggregation. Must be used with secondary aggregation.
+`secondaryReducer`         | REDUCE_NONE  | Defines a secondary reducer to be applied over the primary group by fields. Must be used with secondaryAligner
+`secondaryAligner`         | ALIGN_NONE   | Defines a secondary aligner to be applied over the primary group by fields.
+`secondaryPeriod`          | 0            | Defines a period of seconds over which the secondary aligner is applied.
 `regional_threshold`       |              | Threshold used to evaluate if a regional instance needs to be scaled in or out.
 `multi_regional_threshold` |              | Threshold used to evaluate if a multi-regional instance needs to be scaled in or out.
 `regional_margin`       |      5       | Margin above and below the threshold where the metric value is allowed. If the metric falls outside of the range `[threshold - margin, threshold + margin]`, then the regional instance needs to be scaled in or out.

--- a/poller/poller-core/index.js
+++ b/poller/poller-core/index.js
@@ -129,15 +129,15 @@ function validateCustomMetric(metric) {
 }
 
 function getMetricValue(projectId, spannerInstanceId, metric) {
-  const metricWindow = 1;
-  log(`Get ${metric.name} from ${projectId}/${spannerInstanceId} over ${metric.period} seconds.`);
+  const delta = Math.max(metric.period, metric.secondaryPeriod);
+  log(`Get ${metric.name} from ${projectId}/${spannerInstanceId} over ${delta} seconds.`);
 
   const request = {
     name: 'projects/' + projectId,
     filter: metric.filter,
     interval: {
       startTime: {
-        seconds: Date.now() / 1000 - metric.period * metricWindow,
+        seconds: Date.now() / 1000 - delta,
       },
       endTime: {
         seconds: Date.now() / 1000,

--- a/poller/poller-core/index.js
+++ b/poller/poller-core/index.js
@@ -129,7 +129,11 @@ function validateCustomMetric(metric) {
 }
 
 function getMetricValue(projectId, spannerInstanceId, metric) {
-  const delta = Math.max(metric.period, metric.secondaryPeriod);
+  const delta = Math.max(metric.period, metric.secondaryPeriod || 0);
+  if (Number.isNaN(delta)) {
+    throw new Error(`delta is NaN, period: ${metric.period}, secondaryPeriod: ${metric.secondaryPeriod}`);
+  }
+
   log(`Get ${metric.name} from ${projectId}/${spannerInstanceId} over ${delta} seconds.`);
 
   const request = {

--- a/poller/poller-core/index.js
+++ b/poller/poller-core/index.js
@@ -71,7 +71,7 @@ function buildMetrics(projectId, instanceId) {
           'metric.label.priority="high"',
       reducer: 'REDUCE_SUM',
       aligner: 'ALIGN_MAX',
-      period: 60,
+      period: 300,
       regional_threshold: 65,
       multi_regional_threshold: 45
     },
@@ -81,7 +81,7 @@ function buildMetrics(projectId, instanceId) {
           'metric.type="spanner.googleapis.com/instance/cpu/smoothed_utilization"',
       reducer: 'REDUCE_SUM',
       aligner: 'ALIGN_MAX',
-      period: 60,
+      period: 300,
       regional_threshold: 90,
       multi_regional_threshold: 90
     },
@@ -91,7 +91,7 @@ function buildMetrics(projectId, instanceId) {
           'metric.type="spanner.googleapis.com/instance/storage/utilization"',
       reducer: 'REDUCE_SUM',
       aligner: 'ALIGN_MAX',
-      period: 60,
+      period: 300,
       regional_threshold: 75,
       multi_regional_threshold: 75
     }
@@ -128,9 +128,9 @@ function validateCustomMetric(metric) {
   return true;
 }
 
-function getMaxMetricValue(projectId, spannerInstanceId, metric) {
-  const metricWindow = 5;
-  log(`Get max ${metric.name} from ${projectId}/${spannerInstanceId} over ${metricWindow} minutes.`);
+function getMetricValue(projectId, spannerInstanceId, metric) {
+  const metricWindow = 1;
+  log(`Get ${metric.name} from ${projectId}/${spannerInstanceId} over ${metric.period} seconds.`);
 
   const request = {
     name: 'projects/' + projectId,
@@ -317,7 +317,7 @@ async function getMetrics(spanner) {
   var metrics = [];
   for (const metric of spanner.metrics) {
     var maxMetricValue =
-        await getMaxMetricValue(spanner.projectId, spanner.instanceId, metric);
+        await getMetricValue(spanner.projectId, spanner.instanceId, metric);
 
     var threshold;
     var margin;

--- a/poller/poller-core/index.js
+++ b/poller/poller-core/index.js
@@ -52,7 +52,11 @@ const processingUnitsDefaults = {
 const metricDefaults = {
   period: 60,
   aligner: 'ALIGN_MAX',
-  reducer: 'REDUCE_SUM'
+  reducer: 'REDUCE_SUM',
+  secondaryAligner: 'ALIGN_NONE',
+  secondaryReducer: 'REDUCE_NONE',
+  secondaryPeriod: 0,
+  groupByFields: ""
 };
 const DEFAULT_THRESHOLD_MARGIN = 5;
 
@@ -145,6 +149,14 @@ function getMaxMetricValue(projectId, spannerInstanceId, metric) {
       },
       crossSeriesReducer: metric.reducer,
       perSeriesAligner: metric.aligner,
+      groupByFields: metric.groupByFields
+    },
+    secondaryAggregation: {
+      crossSeriesReducer: metric.secondaryReducer,
+      perSeriesAligner: metric.secondaryAligner,
+      alignmentPeriod: {
+        seconds: metric.secondaryPeriod
+      }
     },
     view: 'FULL'
   };


### PR DESCRIPTION
The default configuration of the high_priority_cpu metric within this project results in over provisioning of Spanner resources as mentioned in #31.

Logically, the CPU should be summed over all regions for an instance, and then maxed over the regions. This requires use of the secondary aggregation exposed by the google cloud monitoring API. This change exposes secondary aggregation to the config.

Secondly, this change removes the hardcoded "metricWindow" functionality, as secondary alignment is already provided by configuration, maxing over 5 minutes results in a tertiary aggregation and makes the autoscaler less configurable.