### PR TITLE
Updates to Spanner state store

### DIFF
--- a/kubernetes/autoscaler-config/autoscaler-config.yaml.template
+++ b/kubernetes/autoscaler-config/autoscaler-config.yaml.template
@@ -25,7 +25,7 @@ data:
       # Delete this stanza if using Firestore for state
       stateDatabase:
         name: spanner
-        instanceId: autoscale-test
+        instanceId: autoscale-test-state
         databaseId: spanner-autoscaler-state
       scalingMethod: LINEAR
       units: NODES

--- a/scaler/scaler-core/state.js
+++ b/scaler/scaler-core/state.js
@@ -77,12 +77,13 @@ module.exports = State;
  */
 class StateSpanner {
   constructor(spanner) {
-    this.projectId = (spanner.stateProjectId != null) ? spanner.stateProjectId :
+    this.stateProjectId = (spanner.stateProjectId != null) ? spanner.stateProjectId :
                                                         spanner.projectId;
-    this.instanceId = spanner.stateDatabase.instanceId;
-    this.databaseId = spanner.stateDatabase.databaseId;
-    const s = new Spanner({projectId: this.projectId});
-    this.table = s.instance(this.instanceId).database(this.databaseId).table('spannerAutoscaler');
+    this.projectId = spanner.projectId;
+    this.instanceId = spanner.instanceId;
+
+    const s = new Spanner({projectId: this.stateProjectId});
+    this.table = s.instance(spanner.stateDatabase.instanceId).database(spanner.stateDatabase.databaseId).table('spannerAutoscaler');
   }
 
   async init() {
@@ -138,7 +139,7 @@ class StateSpanner {
   }
 
   rowId() {
-    return `projects/${this.projectId}/instances/${this.instanceId}/databases/${this.databaseId}`;
+    return `projects/${this.projectId}/instances/${this.instanceId}`;
   }
 
   async updateState(rowData) {

--- a/terraform/gke/README.md
+++ b/terraform/gke/README.md
@@ -243,14 +243,32 @@ In this section you prepare your project for deployment.
 
 ## Using Spanner for Autoscaler state
 
-1.  If you want to use the test Spanner instance for the Autoscaler state
-    database (recommended for testing), set the following variable:
+1.  If you want to store the state in Cloud Spanner and you don't have a Spanner
+    instance yet for that, then set the following variable so that Terraform
+    creates an instance for you named `autoscale-test-state`:
 
     ```sh
     export TF_VAR_terraform_spanner_state=true
     ```
 
-    Alternatively, if you want to manage the state of the Autoscaler in your own
+    It is a best practice not to store the Autoscaler state in the same
+    instance that is being monitored by the Autoscaler.
+
+    Optionally, you can change the name of the instance that Terraform
+    will create:
+
+    ```sh
+    export TF_VAR_state_spanner_name=<INSERT_STATE_SPANNER_INSTANCE_NAME>
+    ```
+
+    If you already have a Spanner instance where state must be stored,
+    only set the the name of your instance:
+
+    ```sh
+    export TF_VAR_state_spanner_name=<INSERT_YOUR_STATE_SPANNER_INSTANCE_NAME>
+    ```
+
+    If you want to manage the state of the Autoscaler in your own
     Cloud Spanner instance, please create the following table in advance:
 
     ```sql

--- a/terraform/gke/main.tf
+++ b/terraform/gke/main.tf
@@ -68,6 +68,7 @@ module "spanner" {
   terraform_spanner_test  = var.terraform_spanner_test
   project_id              = var.project_id
   spanner_name            = var.spanner_name
+  state_spanner_name      = var.state_spanner_name
   poller_sa_email         = module.autoscaler-base.poller_sa_email
   scaler_sa_email         = module.autoscaler-base.scaler_sa_email
 }

--- a/terraform/gke/variables.tf
+++ b/terraform/gke/variables.tf
@@ -45,6 +45,11 @@ variable "terraform_spanner_state" {
   default     = false
 }
 
+variable "state_spanner_name" {
+  type    = string
+  default = "autoscale-test-state"
+}
+
 variable "app_project_id" {
   description = "The project where the Spanner instance(s) live. If specified and different than project_id => centralized deployment"
   type        = string


### PR DESCRIPTION
This PR updates the Spanner state store handling as follows:

- Updates GKE deployment option + docs to match new configuration options added in:
#81 
- Updates the template for GKE autoscaler configuration to match the above
- Updates the Spanner state store logic so that the target scaling instance is used as the state database key, fixing:
#76 