### PR TITLE
Allow for config location to be specified

### DIFF
--- a/kubernetes/autoscaler-config/autoscaler-config-hourly.yaml.template
+++ b/kubernetes/autoscaler-config/autoscaler-config-hourly.yaml.template
@@ -1,0 +1,33 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: autoscaler-config-hourly
+  namespace: spanner-autoscaler
+data:
+  autoscaler-config-hourly.yaml: |
+    ---
+    - projectId: ${PROJECT_ID}
+      instanceId: autoscale-test
+      # Delete this stanza if using Firestore for state
+      stateDatabase:
+        name: spanner
+        instanceId: autoscale-test-state
+        databaseId: spanner-autoscaler-state
+      scalingMethod: DIRECT
+      units: PROCESSING_UNITS
+      minSize: 200
+      maxSize: 200

--- a/kubernetes/autoscaler-config/autoscaler-config.yaml.template
+++ b/kubernetes/autoscaler-config/autoscaler-config.yaml.template
@@ -28,6 +28,6 @@ data:
         instanceId: autoscale-test-state
         databaseId: spanner-autoscaler-state
       scalingMethod: LINEAR
-      units: NODES
-      minSize: 1
-      maxSize: 3
+      units: PROCESSING_UNITS
+      minSize: 100
+      maxSize: 500

--- a/kubernetes/autoscaler-pkg/README.md
+++ b/kubernetes/autoscaler-pkg/README.md
@@ -11,4 +11,6 @@ Config for Spanner Autoscaler
 
 ## Installation
 
-See documentation for installation instructions
+See [documentation][docs] for installation and configuration instructions.
+
+[docs]: ../../terraform/gke/README.md

--- a/kubernetes/autoscaler-pkg/poller/README.md
+++ b/kubernetes/autoscaler-pkg/poller/README.md
@@ -11,4 +11,6 @@ Config for Poller component of Spanner Autoscaler
 
 ## Installation
 
-See documentation for installation instructions
+See [documentation][docs] for installation and configuration instructions.
+
+[docs]: ../../../terraform/gke/README.md

--- a/kubernetes/autoscaler-pkg/poller/poller-hourly.yaml
+++ b/kubernetes/autoscaler-pkg/poller/poller-hourly.yaml
@@ -14,11 +14,11 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: poller
+  name: poller-hourly
   namespace: spanner-autoscaler # kpt-set: ${namespace}
 spec:
   concurrencyPolicy: Forbid
-  schedule: "*/2 * * * *"
+  schedule: "1 * * * *"
   jobTemplate:
     spec:
       template:
@@ -35,13 +35,16 @@ spec:
                 cpu: "250m"
               limits:
                 memory: "256Mi"
+            env:
+            - name: AUTOSCALER_CONFIG
+              value: "/etc/autoscaler-config/autoscaler-config-hourly.yaml"
             volumeMounts:
             - name: config-volume
               mountPath: /etc/autoscaler-config
           volumes:
           - name: config-volume
             configMap:
-              name: autoscaler-config
+              name: autoscaler-config-hourly
           nodeSelector:
             iam.gke.io/gke-metadata-server-enabled: "true"
           restartPolicy: Never

--- a/kubernetes/autoscaler-pkg/scaler/README.md
+++ b/kubernetes/autoscaler-pkg/scaler/README.md
@@ -11,4 +11,6 @@ Config for Scaler component of Spanner Autoscaler
 
 ## Installation
 
-See documentation for installation instructions
+See [documentation][docs] for installation and configuration instructions.
+
+[docs]: ../../../terraform/gke/README.md

--- a/poller/index.js
+++ b/poller/index.js
@@ -25,6 +25,13 @@ async function main() {
 
   var configLocation = DEFAULT_CONFIG_LOCATION;
 
+  /*
+   * If set, the AUTOSCALER_CONFIG environment variable is used to
+   * retrieve the configuration for this instance of the poller.
+   * Please refer to the documentation in the README.md for GKE
+   * deployment for more details.
+   */
+
   if (process.env.AUTOSCALER_CONFIG) {
     configLocation = process.env.AUTOSCALER_CONFIG;
     pollerCore.log(`Using custom config location ${configLocation}`);

--- a/poller/index.js
+++ b/poller/index.js
@@ -19,10 +19,21 @@ const fs         = require('fs/promises');
 
 async function main() {
 
+  const DEFAULT_CONFIG_LOCATION = '/etc/autoscaler-config/autoscaler-config.yaml';
+
   pollerCore.log(`Autoscaler Poller job started`, 'INFO');
 
+  var configLocation = DEFAULT_CONFIG_LOCATION;
+
+  if (process.env.AUTOSCALER_CONFIG) {
+    configLocation = process.env.AUTOSCALER_CONFIG;
+    pollerCore.log(`Using custom config location ${configLocation}`);
+  } else {
+    pollerCore.log(`Using default config location ${configLocation}`);
+  }
+
   try {
-    const data = await fs.readFile('/etc/autoscaler-config.yaml', { encoding: 'utf8' });
+    const data = await fs.readFile(configLocation, { encoding: 'utf8' });
     await pollerCore.checkSpannerScaleMetricsJSON(JSON.stringify(yaml.load(data)))
   } catch (err) {
     pollerCore.log(err);

--- a/terraform/gke/README.md
+++ b/terraform/gke/README.md
@@ -407,6 +407,11 @@ similar process.
     kubectl apply -f autoscaler-pkg/ --recursive
     ```
 
+    The sample configuration creates two schedules to demonstrate autoscaling;
+    a [frequently running schedule][cron-frequent] to dynamically scale the
+    Spanner instance according to utilization, and an [hourly
+    schedule][cron-hourly] to directly scale the Spanner instance every hour.
+
 7.  To prepare to configure the Autoscaler, run the following command:
 
     ```sh
@@ -420,9 +425,20 @@ similar process.
     cat autoscaler-config/autoscaler-config*.yaml
     ```
 
-    You can configure multiple Spanner instances by including multiple stanzas.
-    For the schema of the configuration, see the [Poller configuration][autoscaler-config-params]
-    section.
+    These two files configure each instance of the autoscaler that you
+    scheduled in the previous step. Notice the environment variable
+    `AUTOSCALER_CONFIG`. You can use this variable to reference a configuration
+    that will be used by that individual instance of the autoscaler. This means
+    that you can configure multiple scaling schedules across multiple Spanner
+    instances.
+
+    If you do not supply this value, a default of `autoscaler-config.yaml` will
+    be used.
+
+    You can autoscale multiple Spanner instances on a single schedule by
+    including multiple YAML stanzas in any of the scheduled configurations. For
+    the schema of the configuration, see the [Poller configuration]
+    autoscaler-config-params] section.
 
 9.  If you have chosen to use Firestore to hold the Autoscaler state as described
     above, edit the above files, and remove the following lines:
@@ -448,16 +464,6 @@ similar process.
      ```sh
      kubectl apply -f autoscaler-config/
      ```
-
-     The sample configuration creates two schedules for scaling operations; a
-     frequently running schedule to dynamically scale the Spanner instance
-     according to utilization, and an hourly schedule to directly scale the
-     Spanner instance every hour.
-
-     Note there are some concurrency nuances when using the `DIRECT` scaling
-     method in conjunction with schedulued `LINEAR` or `STEPWISE` scaling, notably
-     relating to the cooldown period and whether a one-off `DIRECT` operation is
-     scheduled concurrently with a `LINEAR` or `STEPWISE` operation.
 
 11.  Any changes made to the configuration files and applied with `kubectl
      apply` will update the Autoscaler configuration.
@@ -503,6 +509,8 @@ following the instructions above.
 <!-- LINKS: https://www.markdownguide.org/basic-syntax/#reference-style-links -->
 [autoscaler-poller]: ../../poller/README.md
 [autoscaler-config-params]: ../../poller/#configuration-parameters
+[cron-frequent]: ../../kubernetes/autoscaler-pkg/poller/poller.yaml
+[cron-hourly]: ../../kubernetes/autoscaler-pkg/poller/poller-hourly.yaml
 
 <!-- GKE deployment architecture -->
 [gke]: https://cloud.google.com/kubernetes-engine

--- a/terraform/gke/README.md
+++ b/terraform/gke/README.md
@@ -410,22 +410,22 @@ similar process.
 7.  To prepare to configure the Autoscaler, run the following command:
 
     ```sh
-    envsubst < autoscaler-config/autoscaler-config.yaml.template > autoscaler-config/autoscaler-config.yaml
+    for template in $(ls autoscaler-config/*.template) ; do envsubst < ${template} > ${template%.*} ; done
     ```
 
 8.  Next, to see how the Autoscaler is configured, run the following command to
     output the example configuration:
 
     ```sh
-    cat autoscaler-config/autoscaler-config.yaml
+    cat autoscaler-config/autoscaler-config*.yaml
     ```
 
-    Each stanza is used to configure a different Spanner instance. For the
-    schema of the configuration, see the
-    [Poller configuration][autoscaler-config-params] section.
+    You can configure multiple Spanner instances by including multiple stanzas.
+    For the schema of the configuration, see the [Poller configuration][autoscaler-config-params]
+    section.
 
 9.  If you have chosen to use Firestore to hold the Autoscaler state as described
-    above, edit the above file, and remove the following lines:
+    above, edit the above files, and remove the following lines:
 
     ```yaml
      stateDatabase:
@@ -440,16 +440,26 @@ similar process.
     [Troubleshooting](#troubleshooting) section for more details.
 
     If you have chosen to use your own Spanner instance, please edit the above
-    configuration file accordingly.
+    configuration files accordingly.
 
 10.  To configure the Autoscaler and begin scaling operations, run the following
      command:
 
      ```sh
-     kubectl apply -f autoscaler-config/autoscaler-config.yaml
+     kubectl apply -f autoscaler-config/
      ```
 
-11.  Any changes made to the configuration file and applied with `kubectl
+     The sample configuration creates two schedules for scaling operations; a
+     frequently running schedule to dynamically scale the Spanner instance
+     according to utilization, and an hourly schedule to directly scale the
+     Spanner instance every hour.
+
+     Note there are some concurrency nuances when using the `DIRECT` scaling
+     method in conjunction with schedulued `LINEAR` or `STEPWISE` scaling, notably
+     relating to the cooldown period and whether a one-off `DIRECT` operation is
+     scheduled concurrently with a `LINEAR` or `STEPWISE` operation.
+
+11.  Any changes made to the configuration files and applied with `kubectl
      apply` will update the Autoscaler configuration.
 
 12.  You can view logs for the Autoscaler components via `kubectl` or the [Cloud


### PR DESCRIPTION
This PR allows for the location of the Poller configuration file to be specified via environment variable, which opens up the possibility of multiple autoscaling schedules for either the same or multiple Spanner instances. If no location is specified, a default location is used.