### PR TITLE
Add option for specifying config directly as JSON

### DIFF
--- a/terraform/cloud-functions/per-project/main.tf
+++ b/terraform/cloud-functions/per-project/main.tf
@@ -71,6 +71,17 @@ module "scheduler" {
   target_pubsub_topic     = module.autoscaler-functions.scaler_topic
   terraform_spanner_state = var.terraform_spanner_state
   state_spanner_name      = var.state_spanner_name
+
+  // Example of passing config as json
+  // json_config             = base64encode(jsonencode([{
+  //   "projectId": "${var.project_id}",
+  //   "instanceId": "${module.spanner.spanner_name}",
+  //   "scalerPubSubTopic": "${module.autoscaler.scaler_topic}",
+  //   "units": "NODES",
+  //   "minSize": 1
+  //   "maxSize": 3,
+  //   "scalingMethod": "LINEAR"
+  // }]))
 }
 
 module "monitoring" {

--- a/terraform/modules/scheduler/main.tf
+++ b/terraform/modules/scheduler/main.tf
@@ -14,6 +14,30 @@
  * limitations under the License.
  */
 
+locals {
+  config = var.json_config != "" ? var.json_config : base64encode(jsonencode([
+      merge ({
+        "projectId" : "${var.project_id}",
+        "instanceId" : "${var.spanner_name}",
+        "scalerPubSubTopic" : "${var.target_pubsub_topic}",
+        "units" : "${var.units}",
+        "minSize" : ${var.min_size},
+        "maxSize" : ${var.max_size},
+        "scalingMethod" : "${var.scaling_method}",
+        "stateDatabase": var.terraform_spanner_state ? {
+          "name":       "spanner",
+          "instanceId": "${var.state_spanner_name}"
+          "databaseId": "spanner-autoscaler-state"
+        } : {
+          "name":       "firestore",
+        }
+      },
+      var.state_project_id != null ? {
+        "stateProjectId" : "${var.state_project_id}"
+      } : {})
+    ]))
+}
+
 resource "google_app_engine_application" "app" {
   project     = var.project_id
   location_id = var.location
@@ -27,27 +51,7 @@ resource "google_cloud_scheduler_job" "poller_job" {
 
   pubsub_target {
     topic_name = var.pubsub_topic
-    data       = base64encode(jsonencode([
-      merge ({
-        "projectId" : "${var.project_id}",
-        "instanceId" : "${var.spanner_name}",
-        "scalerPubSubTopic" : "${var.target_pubsub_topic}",
-        "units" : "PROCESSING_UNITS",
-        "minSize" : 100,
-        "maxSize" : 2000,
-        "scalingMethod" : "LINEAR",
-        "stateDatabase": var.terraform_spanner_state ? {
-          "name":       "spanner",
-          "instanceId": "${var.state_spanner_name}"
-          "databaseId": "spanner-autoscaler-state"
-        } : {
-          "name":       "firestore",
-        }
-      },
-      var.state_project_id != null ? {
-        "stateProjectId" : "${var.state_project_id}"
-      } : {})
-    ]))
+    data       = local.config
   }
 
   depends_on = [google_app_engine_application.app]

--- a/terraform/modules/scheduler/main.tf
+++ b/terraform/modules/scheduler/main.tf
@@ -21,8 +21,8 @@ locals {
         "instanceId" : "${var.spanner_name}",
         "scalerPubSubTopic" : "${var.target_pubsub_topic}",
         "units" : "${var.units}",
-        "minSize" : ${var.min_size},
-        "maxSize" : ${var.max_size},
+        "minSize" : var.min_size,
+        "maxSize" : var.max_size,
         "scalingMethod" : "${var.scaling_method}",
         "stateDatabase": var.terraform_spanner_state ? {
           "name":       "spanner",

--- a/terraform/modules/scheduler/variables.tf
+++ b/terraform/modules/scheduler/variables.tf
@@ -45,6 +45,30 @@ variable "target_pubsub_topic" {
   type = string
 }
 
+variable "units" {
+  type        = string
+  default     = "PROCESSING_UNITS"
+  description = "The measure that spanner size units are being specified in either: PROCESSING_UNITS or NODES"
+}
+
+variable "min_size" {
+  type        = number
+  default     = 100
+  description = "Minimum size that the spanner instance can be scaled in to."
+}
+
+variable "max_size" {
+  type        = number
+  default     = 2000
+  description = "Maximum size that the spanner instance can be scaled out to."
+}
+
+variable "scaling_method" {
+  type        = string
+  default     = "LINEAR"
+  description = "Algorithm that should be used to manage the scaling of the spanner instance: STEPWISE, LINEAR, DIRECT"
+}
+
 variable "terraform_spanner_state" {
   description = "If set to true, Terraform will create a Cloud Spanner DB to hold the Autoscaler state."
   type        = bool
@@ -61,4 +85,10 @@ variable "state_spanner_name" {
   type     = string
   nullable = true
   default  = null
+}
+
+variable "json_config" {
+  type        = string
+  default     = ""
+  description = "Base 64 encoded json that is the autoscaler configuration for the Cloud Scheduler payload. Using this allows for setting autoscaler configuration for multiple spanners and parameters that are not directly exposed through variables."
 }


### PR DESCRIPTION
This PR adds new variables for basic settings to be passed into the Cloud Scheduler module. The new variables provide an easy way for users to specify common settings when managing a single spanner instance.

The PR also adds a variable to directly specify JSON that should be used by Cloud Scheduler.  This variable allows users to define configuration for multiple spanners and set configuration values that are directly enabled via Terraform variables.