### PR TITLE
Move to (more) structured logs

### DIFF
--- a/poller/index.js
+++ b/poller/index.js
@@ -21,7 +21,7 @@ async function main() {
 
   const DEFAULT_CONFIG_LOCATION = '/etc/autoscaler-config/autoscaler-config.yaml';
 
-  pollerCore.log(`Autoscaler Poller job started`, 'INFO');
+  pollerCore.log(`Autoscaler Poller job started`, {severity: 'INFO'});
 
   var configLocation = DEFAULT_CONFIG_LOCATION;
 
@@ -43,7 +43,7 @@ async function main() {
     const data = await fs.readFile(configLocation, { encoding: 'utf8' });
     await pollerCore.checkSpannerScaleMetricsJSON(JSON.stringify(yaml.load(data)))
   } catch (err) {
-    pollerCore.log(err);
+    pollerCore.log('Error in Poller wrapper:', {severity: 'ERROR', payload: err});
   }
 }
 

--- a/poller/poller-core/index.js
+++ b/poller/poller-core/index.js
@@ -104,20 +104,20 @@ function createBaseFilter(projectId, instanceId) {
 }
 
 // checks to make sure required fields are present and populated
-function validateCustomMetric(metric) {
+function validateCustomMetric(metric, projectId, instanceId) {
   if(!metric.name) {
-    log('Missing name parameter for custom metric.', 'INFO');
+    log('Missing name parameter for custom metric.', {severity: 'INFO', projectId: projectId, instanceId: instanceId});
     return false;
   }
 
   if(!metric.filter) {
-    log('Missing filter parameter for custom metric.', 'INFO');
+    log('Missing filter parameter for custom metric.', {severity: 'INFO', projectId: projectId, instanceId: instanceId});
     return false;
   }
 
   if(!(metric.regional_threshold > 0 || metric.multi_regional_threshold > 0)) {
     log('Missing regional_threshold or multi_multi_regional_threshold ' +
-        'parameter for custom metric.', 'INFO');
+        'parameter for custom metric.', {severity: 'INFO', projectId: projectId, instanceId: instanceId});
     return false;
   }
 
@@ -126,7 +126,8 @@ function validateCustomMetric(metric) {
 
 function getMaxMetricValue(projectId, spannerInstanceId, metric) {
   const metricWindow = 5;
-  log(`Get max ${metric.name} from ${projectId}/${spannerInstanceId} over ${metricWindow} minutes.`);
+  log(`Get max ${metric.name} from ${projectId}/${spannerInstanceId} over ${metricWindow} minutes.`,
+    {projectId: projectId, instanceId: spannerInstanceId});
 
   const request = {
     name: 'projects/' + projectId,
@@ -166,20 +167,19 @@ function getMaxMetricValue(projectId, spannerInstanceId, metric) {
 
 function getSpannerMetadata(projectId, spannerInstanceId, units) {
   log(`----- ${projectId}/${spannerInstanceId}: Getting Metadata -----`,
-      'INFO');
+    {severity: 'INFO', projectId: projectId, instanceId: spannerInstanceId});
 
   const spanner = new Spanner({
     projectId: projectId,
   });
   const spannerInstance = spanner.instance(spannerInstanceId);
 
-
   return spannerInstance.getMetadata().then(data => {
     const metadata = data[0];
-    log(`DisplayName:     ${metadata['displayName']}`);
-    log(`NodeCount:       ${metadata['nodeCount']}`);
-    log(`ProcessingUnits: ${metadata['processingUnits']}`);
-    log(`Config:          ${metadata['config'].split('/').pop()}`);
+    log(`DisplayName:     ${metadata['displayName']}`, {projectId: projectId, instanceId: spannerInstanceId});
+    log(`NodeCount:       ${metadata['nodeCount']}`, {projectId: projectId, instanceId: spannerInstanceId});
+    log(`ProcessingUnits: ${metadata['processingUnits']}`, {projectId: projectId, instanceId: spannerInstanceId});
+    log(`Config:          ${metadata['config'].split('/').pop()}`, {projectId: projectId, instanceId: spannerInstanceId});
 
     const spannerMetadata = {
       currentSize: (units == 'NODES') ? metadata['nodeCount'] : metadata['processingUnits'],
@@ -201,10 +201,10 @@ function postPubSubMessage(spanner, metrics) {
   return topic.publish(messageBuffer)
       .then(
           log(`----- Published message to topic: ${spanner.scalerPubSubTopic}`,
-              'INFO', spanner))
+            {severity: 'INFO', projectId: spanner.projectId, instanceId: spanner.instanceId, payload: spanner}))
       .catch(err => {
         log(`An error occurred when publishing the message to ${spanner.scalerPubSubTopic}`,
-            'ERROR', err);
+          {severity: 'ERROR', projectId: spanner.projectId, instanceId: spanner.instanceId, payload: err});
       });
 }
 
@@ -213,10 +213,12 @@ function callScalerHTTP(spanner, metrics) {
 
   return axios.post('http://scaler/metrics', spanner)
     .then(response => {
-      log(`----- Published message to scaler, response ${response.statusText}`, 'INFO', spanner);
+      log(`----- Published message to scaler, response ${response.statusText}`,
+        {severity: 'INFO', projectId: spanner.projectId, instanceId: spanner.instanceId, payload: spanner})
     })
     .catch(err => {
-      log(`An error occurred when calling the scaler`, 'ERROR', err);
+      log(`An error occurred when calling the scaler`,
+        {severity: 'ERROR', projectId: spanner.projectId, instanceId: spanner.instanceId, payload: err});
     });
 }
 
@@ -249,7 +251,7 @@ async function parseAndEnrichPayload(payload) {
       // if minNodes or minSize are provided set the other, and if both are set and not match throw an error
       if(spanners[sIdx].minNodes && !spanners[sIdx].minSize) {
         log(`DEPRECATION: minNodes is deprecated, remove minNodes from your config and instead use: units = 'NODES' and minSize = ${spanners[sIdx].minNodes}`,
-        'WARNING');
+          {severity: 'WARNING', projectId: spanners[sIdx].projectId, instanceId: spanners[sIdx].instanceId});
         spanners[sIdx].minSize = spanners[sIdx].minNodes;
       } else if(spanners[sIdx].minSize && spanners[sIdx].minNodes && spanners[sIdx].minSize != spanners[sIdx].minNodes) {
         throw new Error('INVALID CONFIG: minSize and minNodes are both set but do not match, make them match or only set minSize');
@@ -258,7 +260,7 @@ async function parseAndEnrichPayload(payload) {
       // if maxNodes or maxSize are provided set the other, and if both are set and not match throw an error
       if(spanners[sIdx].maxNodes && !spanners[sIdx].maxSize) {
         log(`DEPRECATION: maxNodes is deprecated, remove maxSize from your config and instead use: units = 'NODES' and maxSize = ${spanners[sIdx].maxNodes}`,
-        'WARNING');
+          {severity: 'WARNING', projectId: spanners[sIdx].projectId, instanceId: spanners[sIdx].instanceId});
         spanners[sIdx].maxSize = spanners[sIdx].maxNodes;
       } else if(spanners[sIdx].maxSize && spanners[sIdx].maxNodes && spanners[sIdx].maxSize != spanners[sIdx].maxNodes) {
         throw new Error('INVALID CONFIG: maxSize and maxNodes are both set but do not match, make them match or only set maxSize');
@@ -282,7 +284,7 @@ async function parseAndEnrichPayload(payload) {
         }
         else {
           var metric = {...metricDefaults, ...metricOverrides[oIdx]};
-          if(validateCustomMetric(metric)) {
+          if(validateCustomMetric(metric, spanners[sIdx].projectId, spanners[sIdx].instanceId)) {
             metric.filter = createBaseFilter(spanners[sIdx].projectId, spanners[sIdx].instanceId) + metric.filter;
             spanners[sIdx].metrics.push(metric);
           }
@@ -298,7 +300,8 @@ async function parseAndEnrichPayload(payload) {
       };
       spannersFound.push(spanners[sIdx]);
     } catch (err) {
-      log(`Unable to retrieve Spanner metadata for ${spanners[sIdx].projectId}/${spanners[sIdx].instanceId}`, 'ERROR', err);
+      log(`Unable to retrieve Spanner metadata for ${spanners[sIdx].projectId}/${spanners[sIdx].instanceId}`,
+        {severity: 'ERROR', projectId: spanners[sIdx].projectId, instanceId: spanners[sIdx].instanceId, payload: err});
     }
   }
 
@@ -307,7 +310,7 @@ async function parseAndEnrichPayload(payload) {
 
 async function getMetrics(spanner) {
   log(`----- ${spanner.projectId}/${spanner.instanceId}: Getting Metrics -----`,
-      'INFO');
+    {severity: 'INFO', projectId: spanner.projectId, instanceId: spanner.instanceId});
   var metrics = [];
   for (const metric of spanner.metrics) {
     var maxMetricValue =
@@ -327,7 +330,8 @@ async function getMetrics(spanner) {
       margin = metric.multi_regional_margin;
     }
 
-    log(`	 ${metric.name} = ${maxMetricValue}, threshold = ${threshold}, margin = ${margin}`);
+    log(`  ${metric.name} = ${maxMetricValue}, threshold = ${threshold}, margin = ${margin}`,
+      {projectId: spanner.projectId, instanceId: spanner.instanceId});
 
     const metricsObject = {
       name: metric.name,
@@ -346,7 +350,8 @@ forwardMetrics = async (forwarderFunction, spanners) => {
       var metrics = await getMetrics(spanner);
       forwarderFunction(spanner, metrics); // Handles exceptions
     } catch (err) {
-      log(`Unable to retrieve metrics for ${spanner.projectId}/${spanner.instanceId}`, 'ERROR', err);
+      log(`Unable to retrieve metrics for ${spanner.projectId}/${spanner.instanceId}`,
+        {severity: 'ERROR', projectId: spanner.projectId, instanceId: spanner.instanceId, payload: err});
     }
   }
 };
@@ -355,10 +360,11 @@ exports.checkSpannerScaleMetricsPubSub = async (pubSubEvent, context) => {
   try {
     const payload = Buffer.from(pubSubEvent.data, 'base64').toString();
     const spanners = await parseAndEnrichPayload(payload);
-    log('Autoscaler poller started (PubSub).', 'DEBUG', spanners);
+    log('Autoscaler poller started (PubSub).', {severity: 'DEBUG', payload: spanners});
     await forwardMetrics(postPubSubMessage, spanners);
   } catch (err) {
-    log(`An error occurred in the Autoscaler poller function (PubSub)`, 'ERROR', err);
+    log(`An error occurred in the Autoscaler poller function (PubSub)`, {severity: 'ERROR', payload: err});
+    log(`JSON payload`, {severity: 'ERROR', payload: payload });
   }
 };
 
@@ -371,7 +377,8 @@ exports.checkSpannerScaleMetricsHTTP = async (req, res) => {
     await forwardMetrics(postPubSubMessage, spanners);
     res.status(200).end();
   } catch (err) {
-    log(`An error occurred in the Autoscaler poller function (HTTP)`, 'ERROR', err);
+    log(`An error occurred in the Autoscaler poller function (HTTP)`, {severity: 'ERROR', payload: err});
+    log(`JSON payload`, {severity: 'ERROR', payload: payload });
     res.status(500).end(err.toString());
   }
 };
@@ -379,11 +386,11 @@ exports.checkSpannerScaleMetricsHTTP = async (req, res) => {
 exports.checkSpannerScaleMetricsJSON = async (payload) => {
   try {
     const spanners = await parseAndEnrichPayload(payload);
-    log('Autoscaler poller started (JSON/HTTP).', 'DEBUG', spanners);
+    log('Autoscaler poller started (JSON/HTTP).', {severity: 'DEBUG', payload: spanners});
     await forwardMetrics(callScalerHTTP, spanners);
   } catch (err) {
-    log(`An error occurred in the Autoscaler poller function (JSON)`, 'ERROR', err);
-    log(`JSON payload`, 'ERROR', payload);
+    log(`An error occurred in the Autoscaler poller function (JSON)`, {severity: 'ERROR', payload: err});
+    log(`JSON payload`, {severity: 'ERROR', payload: payload });
   }
 };
 

--- a/poller/poller-core/utils.js
+++ b/poller/poller-core/utils.js
@@ -18,7 +18,7 @@
  *
  */
 
-function log(message, severity = 'DEBUG', payload) {
+function log(message, {severity = 'DEBUG', projectId, instanceId, payload} = {} ) {
   // Structured logging
   // https://cloud.google.com/functions/docs/monitoring/logging#writing_structured_logs
 
@@ -36,6 +36,8 @@ function log(message, severity = 'DEBUG', payload) {
   const logEntry = {
     message: message,
     severity: severity,
+    projectId: projectId,
+    instanceId: instanceId,
     payload: payload
   };
   console.log(JSON.stringify(logEntry));

--- a/scaler/index.js
+++ b/scaler/index.js
@@ -18,7 +18,7 @@ const scalerCore = require('scaler-core');
 
 function main() {
 
-  scalerCore.log(`Scaler started`, 'INFO');
+  scalerCore.log(`Autoscaler Scaler started`, {severity: 'INFO'});
 
   const app  = express();
   const port = process.env.PORT || 3000;
@@ -36,7 +36,8 @@ function main() {
 
     app.listen(port);
   } catch (err) {
-    scalerCore.log(err);
+    scalerCore.log('Error in Scaler wrapper:', {severity: 'ERROR', payload: err});
+
   }
 }
 

--- a/scaler/scaler-core/scaling-methods/base.js
+++ b/scaler/scaler-core/scaling-methods/base.js
@@ -85,16 +85,20 @@ function logSuggestion(spanner, metric, suggestedSize) {
   const rangeDetails = `${relativeToRange} the range [${range.min}%-${range.max}%]`;
 
   if (metric.name === OVERLOAD_METRIC && spanner.isOverloaded) {
-    log(`${metricDetails} ABOVE the ${OVERLOAD_THRESHOLD} overload threshold => ${getScaleSuggestionMessage(spanner, suggestedSize, RelativeToRange.ABOVE)}`);
+    log(`${metricDetails} ABOVE the ${OVERLOAD_THRESHOLD} overload threshold => ${getScaleSuggestionMessage(spanner, suggestedSize, RelativeToRange.ABOVE)}`,
+      {projectId: spanner.projectId, instanceId: spanner.instanceId});
   } else  {
-    log(`${metricDetails} ${rangeDetails} => ${getScaleSuggestionMessage(spanner, suggestedSize, relativeToRange)}`);
+    log(`${metricDetails} ${rangeDetails} => ${getScaleSuggestionMessage(spanner, suggestedSize, relativeToRange)}`,
+      {projectId: spanner.projectId, instanceId: spanner.instanceId});
   } 
 
 }
 
 function loopThroughSpannerMetrics(spanner, getSuggestedSize) {
-  log(`---- ${spanner.projectId}/${spanner.instanceId}: ${spanner.scalingMethod} size suggestions----`);
-  log(`	Min=${spanner.minSize}, Current=${spanner.currentSize}, Max=${spanner.maxSize} ${spanner.units}`);
+  log(`---- ${spanner.projectId}/${spanner.instanceId}: ${spanner.scalingMethod} size suggestions----`,
+    {projectId: spanner.projectId, instanceId: spanner.instanceId});
+  log(`	Min=${spanner.minSize}, Current=${spanner.currentSize}, Max=${spanner.maxSize} ${spanner.units}`,
+    {projectId: spanner.projectId, instanceId: spanner.instanceId});
 
   var maxSuggestedSize = spanner.minSize;
   spanner.isOverloaded = false;
@@ -115,7 +119,8 @@ function loopThroughSpannerMetrics(spanner, getSuggestedSize) {
   }
 
   maxSuggestedSize = Math.min(maxSuggestedSize, spanner.maxSize);
-  log(`\t=> Final ${spanner.scalingMethod} suggestion: ${maxSuggestedSize} ${spanner.units}`);
+  log(`\t=> Final ${spanner.scalingMethod} suggestion: ${maxSuggestedSize} ${spanner.units}`,
+    {projectId: spanner.projectId, instanceId: spanner.instanceId});
   return maxSuggestedSize;
 }
 

--- a/scaler/scaler-core/scaling-methods/direct.js
+++ b/scaler/scaler-core/scaling-methods/direct.js
@@ -23,8 +23,10 @@
 const {log} = require('../utils.js');
 
 function calculateSize(spanner) {
-  log(`---- DIRECT size suggestions for ${spanner.projectId}/${spanner.instanceId}----`);
-  log(`	Final DIRECT suggestion: ${spanner.maxSize} + ${spanner.units}}`);
+  log(`---- DIRECT size suggestions for ${spanner.projectId}/${spanner.instanceId}----`,
+    {projectId: spanner.projectId, instanceId: spanner.instanceId});
+  log(`	Final DIRECT suggestion: ${spanner.maxSize} + ${spanner.units}}`,
+    {projectId: spanner.projectId, instanceId: spanner.instanceId});
   return spanner.maxSize;
 }
 

--- a/scaler/scaler-core/scaling-methods/linear.js
+++ b/scaler/scaler-core/scaling-methods/linear.js
@@ -38,14 +38,14 @@ function calculateSize(spanner) {
         const limit = spanner.currentSize * (spanner.scaleInLimit/100)
         
         log(`\tscaleInLimit = ${spanner.scaleInLimit}%, so the maximum scale-in allowed for current size of ${spanner.currentSize} is ${limit} ${spanner.units}.`,
-        {severity = 'DEBUG'});
+        {severity: 'DEBUG'});
         
         const originalSuggestedSize = suggestedSize
         suggestedSize = Math.max(suggestedSize, Math.ceil(spanner.currentSize - limit))
 
         if (suggestedSize != originalSuggestedSize) {
           log(`\tscaleInLimit exceeded. Original suggested size was ${originalSuggestedSize} ${spanner.units}, new suggested size is ${suggestedSize} ${spanner.units}.`,
-          {severity = 'DEBUG'});
+          {severity: 'DEBUG'});
         }        
       }
       return maybeRound(suggestedSize, spanner.units, metric.name);

--- a/scaler/scaler-core/scaling-methods/linear.js
+++ b/scaler/scaler-core/scaling-methods/linear.js
@@ -27,7 +27,7 @@ const {maybeRound} = require('../utils.js');
 function calculateSize(spanner) {
   return baseModule.loopThroughSpannerMetrics(spanner, (spanner, metric) => {
     if (baseModule.metricValueWithinRange(metric)) return spanner.currentSize;
-    else return maybeRound(Math.ceil(spanner.currentSize * metric.value / metric.threshold), spanner.units, metric.name);
+    else return maybeRound(Math.ceil(spanner.currentSize * metric.value / metric.threshold), spanner.units, metric.name, spanner.projectId, spanner.instanceId);
   });
 }
 

--- a/scaler/scaler-core/scaling-methods/stepwise.js
+++ b/scaler/scaler-core/scaling-methods/stepwise.js
@@ -35,7 +35,7 @@ function calculateSize(spanner) {
     if(spanner.units.toUpperCase() == 'PROCESSING_UNITS' && spanner.currentSize > 1000 && stepSize < 1000) {
       stepSize = 1000;
       log(`\tCurrent=${spanner.currentSize} ${spanner.units} (> 1000) => overriding stepSize from ${spanner.stepSize} to 1000`,
-      'DEBUG');
+        {projectId: spanner.projectId, instanceId: spanner.instanceId, severity: 'DEBUG'});
     }
 
     var suggestedStep =
@@ -43,7 +43,7 @@ function calculateSize(spanner) {
     if (metric.name === baseModule.OVERLOAD_METRIC && spanner.isOverloaded)
       suggestedStep = spanner.overloadStepSize;
 
-    return maybeRound(Math.max(spanner.currentSize + suggestedStep, spanner.minSize), spanner.units, metric.name);
+    return maybeRound(Math.max(spanner.currentSize + suggestedStep, spanner.minSize), spanner.units, metric.name, spanner.projectId, spanner.instanceId);
   });
 }
 

--- a/scaler/scaler-core/utils.js
+++ b/scaler/scaler-core/utils.js
@@ -36,19 +36,20 @@ function convertMillisecToHumanReadable(millisec) {
   }
 }
 
-function maybeRound(suggestedSize, units, label='') {
+function maybeRound(suggestedSize, units, label='', projectId, instanceId) {
   if (units == 'NODES')
     return suggestedSize;
   else {
     const roundTo = (suggestedSize < 1000) ? 100 : 1000;
     const roundedSize = Math.ceil(suggestedSize/roundTo)*roundTo;
     if (roundedSize != suggestedSize)
-      log(`\t${label}: Suggested ${suggestedSize}, rounded to ${roundedSize} ${units}`);
+      log(`\t${label}: Suggested ${suggestedSize}, rounded to ${roundedSize} ${units}`,
+        {projectId: projectId, instanceId: instanceId});
     return roundedSize;
   }
 }
 
-function log(message, severity = 'DEBUG', payload) {
+function log(message, {severity = 'DEBUG', projectId, instanceId, payload} = {} ) {
   // Structured logging
   // https://cloud.google.com/functions/docs/monitoring/logging#writing_structured_logs
 
@@ -66,6 +67,8 @@ function log(message, severity = 'DEBUG', payload) {
   const logEntry = {
     message: message,
     severity: severity,
+    projectId: projectId,
+    instanceId: instanceId,
     payload: payload
   };
   console.log(JSON.stringify(logEntry));


### PR DESCRIPTION
This PR adds additional structure to each logline, using named arguments for the following fields, which are passed through to the JSON output:

`severity`
`projectId`
`instanceId`
`payload`

The `message` field is retained as unnamed for backwards compatibility.

This means that all loglines are parsed as JSON and can be queried via Cloud Logging. Fixes #86.
