### PR TITLE
Lock Kubernetes version to 1.23

### DIFF
--- a/terraform/modules/autoscaler-cluster/main.tf
+++ b/terraform/modules/autoscaler-cluster/main.tf
@@ -136,10 +136,10 @@ module "cluster" {
   region                 = var.region
   network                = google_compute_network.network.name
   subnetwork             = google_compute_subnetwork.subnetwork.name
+  kubernetes_version     = var.kubernetes_version
   master_ipv4_cidr_block = var.ip_range_master
   ip_range_pods          = var.ip_range_pods
   ip_range_services      = var.ip_range_services
-  release_channel        = var.release_channel
   enable_private_nodes   = true
   enable_shielded_nodes  = true
   network_policy         = true

--- a/terraform/modules/autoscaler-cluster/variables.tf
+++ b/terraform/modules/autoscaler-cluster/variables.tf
@@ -26,6 +26,11 @@ variable "region" {
   description = "The name of the region to run the cluster"
 }
 
+variable "kubernetes_version" {
+  description = "Version string for the master Kubernetes version"
+  default     = "1.23"
+}
+
 variable "ip_range_master" {
   description = "The range for the private master"
 }


### PR DESCRIPTION
This is because the stable channel default version is now 1.24, which is not (yet) supported by the [workload identity module](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/master/modules/workload-identity/README.md).