### PR TITLE
Adding group by to the aggregator for the metrics query.

### DIFF
--- a/poller/poller-core/index.js
+++ b/poller/poller-core/index.js
@@ -145,6 +145,7 @@ function getMaxMetricValue(projectId, spannerInstanceId, metric) {
       },
       crossSeriesReducer: metric.reducer,
       perSeriesAligner: metric.aligner,
+      groupByFields: ['resource.location'],
     },
     view: 'FULL'
   };


### PR DESCRIPTION
Multi-region Cloud Spanner deployments were over-reporting on metrics in the poller because the metric value for each location was being summed.  For example, if every location was seeing 5% the reported CPU utilization was 15%, this could even cause observed utilization to be greater than 100%.

To resolve this issue a group_by has been added to the aggregator and the maximum metric values is selected across regions. This allows a scaling event to be triggered if a read-only region crosses the threshold, keeping all regions below the utilization threshold.