### PR TITLE
Add optional config to support idempotency

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,10 @@ for more information on the deployment options available.
 ## Configuration
 
 The parameters for configuring the Autoscaler are identical regardless of the chosen
-deployment type, but the mechanism for configuration differs slightly.
+deployment type, but the mechanism for configuration differs slightly:
+
+*   [Cloud Functions](terraform/cloud-functions/README.md#configuration)
+*   [Google Kubernetes Engine (GKE)](terraform/gke/README.md#building-and-deploying-the-autoscaler-services)
 
 ## Licensing
 

--- a/terraform/cloud-functions/README.md
+++ b/terraform/cloud-functions/README.md
@@ -172,6 +172,15 @@ You can find the details about the parameters and their default values in the
 The Autoscaler is now configured and will start monitoring and scaling your
 instances in the next scheduled job run.
 
+Note that in the default configuration, any changes made to the Cloud Scheduler
+configuration as described above will be reset by a subsequent Terraform run.
+If you would prefer to manage the Cloud Scheduler configuration manually
+following its initial creation, i.e. using the Google Cloud Web Console, the
+`gcloud` CLI, or any other non-Terraform mechanism, please [see this link]
+[cloud-scheduler-lifecycle]. Without this change, the Terraform configuration
+will remain the source of truth, and any direct modifications to the Cloud
+Scheduler configuration will be reset on the next Terraform run.
+
 ## Monitoring
 
 The [monitoring](../modules/monitoring) module is an optional module for monitoring,
@@ -189,4 +198,5 @@ and creates the following resources.
 [cloud-monitoring]: https://cloud.google.com/monitoring
 [cloud-scheduler]: https://cloud.google.com/scheduler
 [cloud-scheduler-console]: https://console.cloud.google.com/cloudscheduler
+[cloud-scheduler-lifecycle]: ../../terraform/modules/scheduler/main.tf#L67
 [json]: https://www.json.org/

--- a/terraform/gke/README.md
+++ b/terraform/gke/README.md
@@ -438,7 +438,7 @@ similar process.
     You can autoscale multiple Spanner instances on a single schedule by
     including multiple YAML stanzas in any of the scheduled configurations. For
     the schema of the configuration, see the [Poller configuration]
-    autoscaler-config-params] section.
+    [autoscaler-config-params] section.
 
 9.  If you have chosen to use Firestore to hold the Autoscaler state as described
     above, edit the above files, and remove the following lines:

--- a/terraform/modules/scheduler/main.tf
+++ b/terraform/modules/scheduler/main.tf
@@ -54,5 +54,30 @@ resource "google_cloud_scheduler_job" "poller_job" {
     data       = local.config
   }
 
+  retry_config {
+    retry_count          = 0
+    max_backoff_duration = "3600s"
+    max_retry_duration   = "0s"
+    max_doublings        = 5
+    min_backoff_duration = "5s"
+  }
+
   depends_on = [google_app_engine_application.app]
+
+  /**
+   * Uncomment this stanza if you would prefer to manage the Cloud Scheduler
+   * configuration manually following its initial creation, i.e. using the
+   * Google Cloud Web Console, the gcloud CLI, or any other non-Terraform
+   * mechanism. Without this change, the Terraform configuration will remain
+   * the source of truth, and any direct modifications to the Cloud Scheduler
+   * configuration will be reset on the next Terraform run. Please see the
+   * following link for more details:
+   *
+   * https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes
+   */
+  /*
+  lifecycle {
+    ignore_changes = [pubsub_target[0].data]
+  }
+  */
 }


### PR DESCRIPTION
This PR adds an optional Terraform stanza that can be applied to allow changes made directly to the Cloud Scheduler configuration to be ignored by Terraform. This means that the source of truth is configurable and better supports idempotency. The addition of the `retry_config` stanza is to ensure that default values added by the back-end are reflected in the Terraform config to avoid permadiff. Fixes #105.