### PR TITLE
Simplify and restrict Poller service account permissions

### DIFF
--- a/terraform/modules/autoscaler-base/main.tf
+++ b/terraform/modules/autoscaler-base/main.tf
@@ -26,10 +26,3 @@ resource "google_service_account" "scaler_sa" {
   account_id   = "scaler-sa"
   display_name = "Autoscaler - Scaler Function Service Account"
 }
-
-resource "google_project_iam_member" "poller_sa_spanner" {
-  project = var.project_id
-  role    = "roles/spanner.viewer"
-
-  member = "serviceAccount:${google_service_account.poller_sa.email}"
-}


### PR DESCRIPTION
This PR simplifies and makes more granular the permissions for the Poller service account by introducing a custom IAM role (in the same way as is currently done for the Scaler component). This addresses two issues:

- IAM permissions for the Poller component service account were multiply assigned in different Terraform source files
- Overlapping IAM roles were being applied (`roles/spanner.viewer` and `roles/monitoring.viewer`), which made reasoning about the permissions more difficult

Fixes #111.