### PR TITLE
Add random suffix to custom role IDs

### DIFF
--- a/terraform/cloud-functions/distributed/app-project/.terraform.lock.hcl
+++ b/terraform/cloud-functions/distributed/app-project/.terraform.lock.hcl
@@ -39,3 +39,22 @@ provider "registry.terraform.io/hashicorp/google" {
     "zh:f80bf9c3bef00ba4738d46c7e6170d1eb7f49e20a081acffa33a39035df86326",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.5.1"
+  hashes = [
+    "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
+    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
+    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
+    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
+    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
+    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
+    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
+    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
+    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
+    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
+    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+  ]
+}

--- a/terraform/cloud-functions/per-project/.terraform.lock.hcl
+++ b/terraform/cloud-functions/per-project/.terraform.lock.hcl
@@ -39,3 +39,22 @@ provider "registry.terraform.io/hashicorp/google" {
     "zh:f80bf9c3bef00ba4738d46c7e6170d1eb7f49e20a081acffa33a39035df86326",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.5.1"
+  hashes = [
+    "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
+    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
+    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
+    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
+    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
+    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
+    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
+    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
+    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
+    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
+    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+  ]
+}

--- a/terraform/modules/spanner/main.tf
+++ b/terraform/modules/spanner/main.tf
@@ -53,9 +53,13 @@ resource "google_spanner_database" "test-database" {
 ## on the monitored Spanner instance
 ##
 
+resource "random_id" "role_suffix" {
+  byte_length = 4
+}
+
 # Limited role for Poller
 resource "google_project_iam_custom_role" "metrics_viewer_iam_role" {
-  role_id     = "spannerAutoscalerMetricsViewer"
+  role_id     = "spannerAutoscalerMetricsViewer_${random_id.role_suffix.hex}"
   title       = "Spanner Autoscaler Metrics Viewer Role"
   description = "Allows a principal to get Spanner instances and view time series metrics"
   permissions = ["spanner.instances.get", "monitoring.timeSeries.list"]
@@ -70,7 +74,7 @@ resource "google_project_iam_member" "poller_metrics_viewer_iam" {
 
 # Limited role for Scaler
 resource "google_project_iam_custom_role" "capacity_manager_iam_role" {
-  role_id     = "spannerAutoscalerCapacityManager"
+  role_id     = "spannerAutoscalerCapacityManager_${random_id.role_suffix.hex}"
   title       = "Spanner Autoscaler Capacity Manager Role"
   description = "Allows a principal to scale spanner instances"
   permissions = ["spanner.instanceOperations.get", "spanner.instances.update"]


### PR DESCRIPTION
This PR adds a random (hex) string suffix to the identifiers of the two created custom roles, making them of the form:

- `spannerAutoscalerMetricsViewer_hhhhhh`
- `spannerAutoscalerCapacityManager_hhhhhh`

This means that (re)build operations will succeed without encountering the errors described in #115, which this PR fixes. 