### PR TITLE
Update poller: add support for scalerURL

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x]
+        node-version: [18.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -36,7 +36,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x]
+        node-version: [18.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/poller/README.md
+++ b/poller/README.md
@@ -101,6 +101,7 @@ Key                      | Default Value  | Description
 `scaleInLimit`           | `undefined`    | Percentage (integer) of the total instance size that can be removed in a scale in event when using the linear algorithm. For example if set to `20`, only 20% of the instance size can be removed in a single scaling event, when `scaleInLimit` is `undefined` a limit is not enforced.
 `minNodes` (DEPRECATED)  | 1              | DEPRECATED: Minimum number of Cloud Spanner nodes that the instance can be scaled IN to.
 `maxNodes` (DEPRECATED)  | 3              | DEPRECATED: Maximum number of Cloud Spanner nodes that the instance can be scaled OUT to.
+`scalerURL`              | `http://scaler`| URL where the scaler service receives HTTP requests.
 
 ## Metrics parameters
 

--- a/poller/poller-core/index.js
+++ b/poller/poller-core/index.js
@@ -217,9 +217,12 @@ function postPubSubMessage(spanner, metrics) {
 }
 
 function callScalerHTTP(spanner, metrics) {
+  spanner.scalerURL ||= 'http://scaler';
+  const url = new URL('/metrics', spanner.scalerURL);
+  
   spanner.metrics = metrics;
 
-  return axios.post('http://scaler/metrics', spanner)
+  return axios.post(url.toString(), spanner)
     .then(response => {
       log(`----- Published message to scaler, response ${response.statusText}`,
         {severity: 'INFO', projectId: spanner.projectId, instanceId: spanner.instanceId, payload: spanner})

--- a/poller/poller-core/index.js
+++ b/poller/poller-core/index.js
@@ -219,7 +219,7 @@ function postPubSubMessage(spanner, metrics) {
 function callScalerHTTP(spanner, metrics) {
   spanner.scalerURL ||= 'http://scaler';
   const url = new URL('/metrics', spanner.scalerURL);
-  
+
   spanner.metrics = metrics;
 
   return axios.post(url.toString(), spanner)


### PR DESCRIPTION
The current behavior hard code the scaler url to `http://scaler`.
This PR add support for custom scaler URL while keeping the same behavior by default.

Upgrade tests from nodejs 10 to 18 since `||=` is not supported by the current version.
This is an actively supported version and used in the Dockerfile of the repository