### PR TITLE
Updated scaler readme to be less pedantic

### DIFF
--- a/scaler/README.md
+++ b/scaler/README.md
@@ -51,8 +51,11 @@ The Scaler component supports three scaling methods out of the box:
 
 *   [LINEAR](scaler-core/scaling-methods/linear.js): This method suggests
     adding or removing nodes or processing units calculated with a simple
-    linear [cross multiplication][cross-multiplication]. This way, the new
-    number of nodes or processing units is
+    linear [cross multiplication][cross-multiplication].
+    In other words, the new number of processing units divided by the max
+    number of processing units is equal to the metric value divided by the
+    metric threshold value.
+    Using this method, the new number of nodes or processing units is
     [directly proportional][directly-proportional] to the current resource
     utilization.
 
@@ -139,4 +142,4 @@ The parameters `minNodes`, `maxNodes` and `currentNodes` are deprecated.
 [autoscaler-poller-parameters]: ../poller/README.md#configuration-parameters
 [spanner-regional]: https://cloud.google.com/spanner/docs/instances#configuration
 [directly-proportional]: https://en.wikipedia.org/wiki/Proportionality_(mathematics)#Direct_proportionality
-[cross-multiplication]: https://en.wikipedia.org/wiki/Cross-multiplication
+[cross-multiplication]: https://github.com/cloudspannerecosystem/autoscaler/blob/83ed3f5d37eceedd031ff679c1f2b9de7b0a3dbf/scaler/scaler-core/scaling-methods/linear.js#L35


### PR DESCRIPTION
It's not super helpful to mention that `LINEAR` scaling uses cross-multiplication to calculate a new instance size that is proportional to metrics in some way, and then not actually describe the calculation.  In fact, it's a little hostile to instead provide a pedantic link to the wikipedia page on Cross-multiplication.

In this PR we link to the line in code that performs the calculation and also explain just what is meant by this line. 