### PR TITLE
Add user-agent string

### DIFF
--- a/poller/poller-core/index.js
+++ b/poller/poller-core/index.js
@@ -178,6 +178,7 @@ function getSpannerMetadata(projectId, spannerInstanceId, units) {
 
   const spanner = new Spanner({
     projectId: projectId,
+    userAgent: "cloud-solutions/spanner-autoscaler-poller-usage-v1.0"
   });
   const spannerInstance = spanner.instance(spannerInstanceId);
 

--- a/scaler/scaler-core/index.js
+++ b/scaler/scaler-core/index.js
@@ -60,6 +60,7 @@ async function scaleSpannerInstance(spanner, suggestedSize) {
 
   const spannerClient = new Spanner({
     projectId: spanner.projectId,
+    userAgent: "cloud-solutions/spanner-autoscaler-scaler-usage-v1.0"
   });
 
   return spannerClient.instance(spanner.instanceId)

--- a/terraform/modules/autoscaler-cluster/main.tf
+++ b/terraform/modules/autoscaler-cluster/main.tf
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+terraform {
+  provider_meta "google" {
+    module_name = "cloud-solutions/spanner-autoscaler-deploy-gke-v1.0"
+  }
+}
+
 resource "google_service_account" "service_account" {
   project      = var.project_id
   account_id   = "cluster-sa"

--- a/terraform/modules/autoscaler-functions/main.tf
+++ b/terraform/modules/autoscaler-functions/main.tf
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+terraform {
+  provider_meta "google" {
+    module_name = "cloud-solutions/spanner-autoscaler-deploy-cf-v1.0"
+  }
+}
+
 // PubSub
 
 resource "google_pubsub_topic" "poller_topic" {


### PR DESCRIPTION
This PR adds a `user-agent` string to the `poller`, `scaler`, and to the Terraform definitions for the two main deployment models (Cloud Functions and GKE).