### PR TITLE
Adding var linearRoundingPrecision for LINEAR scaling rounding

### DIFF
--- a/poller/README.md
+++ b/poller/README.md
@@ -23,20 +23,23 @@
 
 ## Table of Contents
 
-*   [Table of Contents](#table-of-contents)
-*   [Overview](#overview)
-*   [Configuration parameters](#configuration-parameters)
-    *   [Required](#required)
-    *   [Optional](#optional)
-*   [Metrics parameters](#metrics-parameters)
-    *   [Selectors](#selectors)
-    *   [Parameters](#parameters)
-*   [Custom metrics, thresholds and margins](#custom-metrics-thresholds-and-margins)
-    *   [Thresholds](#thresholds)
-    *   [Margins](#margins)
-    *   [Metrics](#metrics)
-*   [Example configuration for Cloud Functions](#example-configuration-for-cloud-functions)
-*   [Example configuration for Google Kubernetes Engine](#example-configuration-for-google-kubernetes-engine)
+- [Table of Contents](#table-of-contents)
+- [Overview](#overview)
+- [Configuration parameters](#configuration-parameters)
+  - [Required](#required)
+  - [Required for a Cloud Functions deployment](#required-for-a-cloud-functions-deployment)
+  - [Optional](#optional)
+- [Metrics parameters](#metrics-parameters)
+  - [Selectors](#selectors)
+  - [Parameters](#parameters)
+- [Custom metrics, thresholds and margins](#custom-metrics-thresholds-and-margins)
+  - [Thresholds](#thresholds)
+  - [Margins](#margins)
+  - [Metrics](#metrics)
+- [State Database](#state-database)
+  - [State Managing in Cloud Spanner](#state-managing-in-cloud-spanner)
+- [Example configuration for Cloud Functions](#example-configuration-for-cloud-functions)
+- [Example configuration for Google Kubernetes Engine](#example-configuration-for-google-kubernetes-engine)
 
 ## Overview
 
@@ -102,6 +105,7 @@ Key                      | Default Value  | Description
 `minNodes` (DEPRECATED)  | 1              | DEPRECATED: Minimum number of Cloud Spanner nodes that the instance can be scaled IN to.
 `maxNodes` (DEPRECATED)  | 3              | DEPRECATED: Maximum number of Cloud Spanner nodes that the instance can be scaled OUT to.
 `scalerURL`              | `http://scaler`| URL where the scaler service receives HTTP requests.
+`linearRoundingPrecision`| 1000           | Number used for suggested size comparison that rounds up by 100 PU if suggestedSize is less than this value, or rounds up by 1000 PU if suggestedSize is greater than this value. Only used when scaling with the `LINEAR` method.
 
 ## Metrics parameters
 

--- a/scaler/scaler-core/scaling-methods/linear.js
+++ b/scaler/scaler-core/scaling-methods/linear.js
@@ -46,9 +46,11 @@ function calculateSize(spanner) {
         if (suggestedSize != originalSuggestedSize) {
           log(`\tscaleInLimit exceeded. Original suggested size was ${originalSuggestedSize} ${spanner.units}, new suggested size is ${suggestedSize} ${spanner.units}.`,
           {severity: 'DEBUG', projectId: spanner.projectId, instanceId: spanner.instanceId});
-        }        
+        }
       }
-      return maybeRound(suggestedSize, spanner.units, metric.name, spanner.projectId, spanner.instanceId);
+      var linearRoundingPrecision = spanner.linearRoundingPrecision || 1000;
+
+      return maybeRound(suggestedSize, spanner.units, metric.name, spanner.projectId, spanner.instanceId, linearRoundingPrecision);
     }
   });
 }

--- a/scaler/scaler-core/test/scaling-methods/linear.test.js
+++ b/scaler/scaler-core/test/scaling-methods/linear.test.js
@@ -75,6 +75,14 @@ describe('#linear.calculateSize', () => {
     calculateSize(spanner).should.equal(2000);
     assert.equals(callbackStub.callCount, 1);
   });
+
+  it('should return the number of processing units rounded to next 100 if over 1000', () => {
+    const spanner = createSpannerParameters({currentSize : 900, linearRoundingPrecision: 10000}, true);
+    const callbackStub = stubBaseModule(spanner, {value : 85, threshold : 65}, false);
+
+    calculateSize(spanner).should.equal(1200);
+    assert.equals(callbackStub.callCount, 1);
+  });
   
   it('should return the higher instance size if a scaleInLimit is specified', () => {
     const spanner = createSpannerParameters({units : 'NODES', currentSize: 20, scaleInLimit: 10}, true);

--- a/scaler/scaler-core/utils.js
+++ b/scaler/scaler-core/utils.js
@@ -36,11 +36,11 @@ function convertMillisecToHumanReadable(millisec) {
   }
 }
 
-function maybeRound(suggestedSize, units, label='', projectId, instanceId) {
+function maybeRound(suggestedSize, units, label='', projectId, instanceId, linearRoundingPrecision) {
   if (units == 'NODES')
     return suggestedSize;
   else {
-    const roundTo = (suggestedSize < 1000) ? 100 : 1000;
+    const roundTo = (suggestedSize < linearRoundingPrecision) ? 100 : 1000;
     const roundedSize = Math.ceil(suggestedSize/roundTo)*roundTo;
     if (roundedSize != suggestedSize)
       log(`\t${label}: Suggested ${suggestedSize}, rounded to ${roundedSize} ${units}`,


### PR DESCRIPTION
This PR adds a new user configurable variable `linearRoundingPrecision`. 

We ran into an issue where we wanted the rounding function to scale by 100 even when our PU was over 1000. This gives us that control. Default value is set to 1000 PU, which was the existing value. 

Let me know if anything needs to change. Thank you!