### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,49 @@
+---
+updates:
+  - directory: "/"
+    package-ecosystem: "github-actions"
+    schedule:
+      interval: "weekly"
+  - directory: "/"
+    package-ecosystem: "npm"
+    schedule:
+      interval: "weekly"
+  - directory: "/src"
+    package-ecosystem: "npm"
+    schedule:
+      interval: "weekly"
+  - directory: "/src/forwarder"
+    package-ecosystem: "npm"
+    schedule:
+      interval: "weekly"
+  - directory: "/src/poller"
+    package-ecosystem: "npm"
+    schedule:
+      interval: "weekly"
+  - directory: "/src/poller/poller-core"
+    package-ecosystem: "npm"
+    schedule:
+      interval: "weekly"
+  - directory: "/src/scaler"
+    package-ecosystem: "npm"
+    schedule:
+      interval: "weekly"
+  - directory: "/src/scaler/scaler-core"
+    package-ecosystem: "npm"
+    schedule:
+      interval: "weekly"
+
+  - directory: "/src/poller"
+    package-ecosystem: "docker"
+    schedule:
+      interval: "weekly"
+  - directory: "/src/scaler"
+    package-ecosystem: "docker"
+    schedule:
+      interval: "weekly"
+  - directory: "/src/forwarder"
+    package-ecosystem: "docker"
+    schedule:
+      interval: "weekly"
+version: 2
+...

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -33,6 +33,10 @@ updates:
     schedule:
       interval: "weekly"
 
+  - directory: "/src"
+    package-ecosystem: "docker"
+    schedule:
+      interval: "weekly"
   - directory: "/src/poller"
     package-ecosystem: "docker"
     schedule:


### PR DESCRIPTION
Dependabot will propose PRs to bring dependancies up to date according to the rules in package.json

(we use [Caret ranges](https://docs.npmjs.com/cli/v6/using-npm/semver#caret-ranges-123-025-004) so this will only propose minor and patch level version updates, not major version updates)

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates

