### PR TITLE
Add missing 'ignore' to Dependabot configuration.

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -67,6 +67,7 @@ updates:
     package-ecosystem: "npm"
     schedule:
       interval: "weekly"
+    ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
 


### PR DESCRIPTION
Add missing `ignore` to Dependabot configuration.