### PR TITLE
Require explicit region/zone parameters, remove defaults

### DIFF
--- a/terraform/cloud-functions/distributed/app-project/main.tf
+++ b/terraform/cloud-functions/distributed/app-project/main.tf
@@ -43,6 +43,7 @@ module "spanner" {
   terraform_spanner_state        = var.terraform_spanner_state
   terraform_spanner_test         = var.terraform_spanner_test
   project_id                     = var.project_id
+  region                         = var.region
   spanner_name                   = var.spanner_name
   spanner_state_name             = var.spanner_state_name
   spanner_test_processing_units  = var.spanner_test_processing_units
@@ -63,6 +64,7 @@ module "scheduler" {
   source = "../../../modules/scheduler"
 
   project_id              = var.project_id
+  location                = var.region
   spanner_name            = var.spanner_name
   pubsub_topic            = module.forwarder.forwarder_topic
   target_pubsub_topic     = data.terraform_remote_state.autoscaler.outputs.scaler_topic

--- a/terraform/cloud-functions/distributed/app-project/variables.tf
+++ b/terraform/cloud-functions/distributed/app-project/variables.tf
@@ -19,13 +19,11 @@ variable "project_id" {
 }
 
 variable "region" {
-  type    = string
-  default = "us-central1"
+  type = string
 }
 
 variable "zone" {
-  type    = string
-  default = "us-central1-c"
+  type = string
 }
 
 variable "spanner_name" {

--- a/terraform/cloud-functions/distributed/autoscaler-project/main.tf
+++ b/terraform/cloud-functions/distributed/autoscaler-project/main.tf
@@ -51,6 +51,7 @@ module "autoscaler-functions" {
   source = "../../../modules/autoscaler-functions"
 
   project_id          = var.project_id
+  region              = var.region
   poller_sa_email     = google_service_account.poller_sa.email
   scaler_sa_email     = google_service_account.scaler_sa.email
   forwarder_sa_emails = var.forwarder_sa_emails

--- a/terraform/cloud-functions/distributed/autoscaler-project/variables.tf
+++ b/terraform/cloud-functions/distributed/autoscaler-project/variables.tf
@@ -19,13 +19,11 @@ variable "project_id" {
 }
 
 variable "region" {
-  type    = string
-  default = "us-central1"
+  type = string
 }
 
 variable "zone" {
-  type    = string
-  default = "us-central1-c"
+  type = string
 }
 
 variable "forwarder_sa_emails" {

--- a/terraform/cloud-functions/per-project/main.tf
+++ b/terraform/cloud-functions/per-project/main.tf
@@ -51,6 +51,7 @@ module "autoscaler-functions" {
   source = "../../modules/autoscaler-functions"
 
   project_id      = var.project_id
+  region          = var.region
   poller_sa_email = google_service_account.poller_sa.email
   scaler_sa_email = google_service_account.scaler_sa.email
 }
@@ -69,6 +70,7 @@ module "spanner" {
   terraform_spanner_state        = var.terraform_spanner_state
   terraform_spanner_test         = var.terraform_spanner_test
   project_id                     = local.app_project_id
+  region                         = var.region
   spanner_name                   = var.spanner_name
   spanner_state_name             = var.spanner_state_name
   spanner_test_processing_units  = var.spanner_test_processing_units
@@ -81,6 +83,7 @@ module "scheduler" {
   source = "../../modules/scheduler"
 
   project_id              = var.project_id
+  location                = var.region
   spanner_name            = var.spanner_name
   pubsub_topic            = module.autoscaler-functions.poller_topic
   target_pubsub_topic     = module.autoscaler-functions.scaler_topic

--- a/terraform/cloud-functions/per-project/test/per_project_e2e_test.go
+++ b/terraform/cloud-functions/per-project/test/per_project_e2e_test.go
@@ -145,6 +145,8 @@ func TestPerProjectEndToEndDeployment(t *testing.T) {
 			TerraformDir: terraformDir,
 			Vars: map[string]interface{}{
 				"project_id":                    config.ProjectId,
+				"region":                        "us-central1",
+				"zone":                          "us-central1-a",
 				"spanner_name":                  spannerName,
 				"terraform_spanner_test":        true,
 				"spanner_test_processing_units": spannerTestProcessingUnits,

--- a/terraform/cloud-functions/per-project/variables.tf
+++ b/terraform/cloud-functions/per-project/variables.tf
@@ -19,13 +19,11 @@ variable "project_id" {
 }
 
 variable "region" {
-  type    = string
-  default = "us-central1"
+  type = string
 }
 
 variable "zone" {
-  type    = string
-  default = "us-central1-c"
+  type = string
 }
 
 variable "spanner_name" {

--- a/terraform/gke/decoupled/main.tf
+++ b/terraform/gke/decoupled/main.tf
@@ -84,6 +84,7 @@ module "spanner" {
   terraform_spanner_state        = var.terraform_spanner_state
   terraform_spanner_test         = var.terraform_spanner_test
   project_id                     = var.project_id
+  region                         = var.region
   spanner_name                   = var.spanner_name
   spanner_state_name             = var.spanner_state_name
   spanner_test_processing_units  = var.spanner_test_processing_units

--- a/terraform/gke/decoupled/variables.tf
+++ b/terraform/gke/decoupled/variables.tf
@@ -19,13 +19,11 @@ variable "project_id" {
 }
 
 variable "region" {
-  type    = string
-  default = "us-central1"
+  type = string
 }
 
 variable "zone" {
-  type    = string
-  default = "us-central1-c"
+  type = string
 }
 
 variable "spanner_name" {

--- a/terraform/gke/unified/main.tf
+++ b/terraform/gke/unified/main.tf
@@ -80,6 +80,7 @@ module "spanner" {
   terraform_spanner_state        = var.terraform_spanner_state
   terraform_spanner_test         = var.terraform_spanner_test
   project_id                     = var.project_id
+  region                         = var.region
   spanner_name                   = var.spanner_name
   spanner_state_name             = var.spanner_state_name
   spanner_test_processing_units  = var.spanner_test_processing_units

--- a/terraform/gke/unified/variables.tf
+++ b/terraform/gke/unified/variables.tf
@@ -19,13 +19,11 @@ variable "project_id" {
 }
 
 variable "region" {
-  type    = string
-  default = "us-central1"
+  type = string
 }
 
 variable "zone" {
-  type    = string
-  default = "us-central1-c"
+  type = string
 }
 
 variable "spanner_name" {

--- a/terraform/modules/autoscaler-base/variables.tf
+++ b/terraform/modules/autoscaler-base/variables.tf
@@ -18,11 +18,6 @@ variable "project_id" {
   type = string
 }
 
-variable "region" {
-  type    = string
-  default = "us-central1"
-}
-
 variable "poller_sa_email" {
   type = string
 }

--- a/terraform/modules/autoscaler-functions/variables.tf
+++ b/terraform/modules/autoscaler-functions/variables.tf
@@ -19,8 +19,7 @@ variable "project_id" {
 }
 
 variable "region" {
-  type    = string
-  default = "us-central1"
+  type = string
 }
 
 variable "nodejs_version" {

--- a/terraform/modules/firestore/variables.tf
+++ b/terraform/modules/firestore/variables.tf
@@ -25,8 +25,3 @@ variable "poller_sa_email" {
 variable "scaler_sa_email" {
   type = string
 }
-
-variable "region" {
-  type    = string
-  default = "us-central1"
-}

--- a/terraform/modules/forwarder/variables.tf
+++ b/terraform/modules/forwarder/variables.tf
@@ -19,8 +19,7 @@ variable "project_id" {
 }
 
 variable "region" {
-  type    = string
-  default = "us-central1"
+  type = string
 }
 
 variable "nodejs_version" {

--- a/terraform/modules/scheduler/main.tf
+++ b/terraform/modules/scheduler/main.tf
@@ -40,7 +40,7 @@ locals {
 
 resource "google_app_engine_application" "app" {
   project     = var.project_id
-  location_id = var.location
+  location_id = var.location == "us-central1" ? "us-central" : var.location
 }
 
 resource "google_cloud_scheduler_job" "poller_job" {

--- a/terraform/modules/scheduler/variables.tf
+++ b/terraform/modules/scheduler/variables.tf
@@ -19,8 +19,7 @@ variable "project_id" {
 }
 
 variable "location" {
-  type    = string
-  default = "us-central"
+  type = string
 }
 
 variable "schedule" {

--- a/terraform/modules/spanner/variables.tf
+++ b/terraform/modules/spanner/variables.tf
@@ -18,6 +18,10 @@ variable "project_id" {
   type = string
 }
 
+variable "region" {
+  type = string
+}
+
 variable "terraform_spanner_test" {
   description = "If set to true, Terraform will create a Cloud Spanner instance and DB."
   type        = bool
@@ -42,12 +46,12 @@ variable "spanner_state_processing_units" {
 
 variable "spanner_name" {
   description = "Name of the Spanner instance to be autoscaled."
-  type    = string
+  type        = string
 }
 
 variable "spanner_state_name" {
   description = "Name of the Spanner instance where the Autoscaler state is stored."
-  type    = string
+  type        = string
 }
 
 variable "poller_sa_email" {
@@ -56,9 +60,4 @@ variable "poller_sa_email" {
 
 variable "scaler_sa_email" {
   type = string
-}
-
-variable "region" {
-  type    = string
-  default = "us-central1"
 }


### PR DESCRIPTION
Following the discovery of missing location (region/zone) parameters that were causing issues during deployment, this PR removes all default region and zone parameters in favour of requiring explicit configuration. Removing these defaults does not require a change to documentation and means that any misconfiguration (or as-yet-undiscovered Terraform issues) will be easier to debug.