### PR TITLE
Remove 'zone' parameter

### DIFF
--- a/terraform/cloud-functions/distributed/README.md
+++ b/terraform/cloud-functions/distributed/README.md
@@ -137,13 +137,12 @@ Autoscaler infrastructure, with the exception of Cloud Scheduler, lives.
     gcloud config set project "${AUTOSCALER_PROJECT_ID}"
     ```
 
-4.  Choose the [region and zone][region-and-zone] and
+4.  Choose the [region][region-and-zone] and
     [App Engine Location][app-engine-location] where the Autoscaler
     infrastructure will be located.
 
     ```sh
     export AUTOSCALER_REGION=us-central1
-    export AUTOSCALER_ZONE=us-central1-c
     export AUTOSCALER_APP_ENGINE_LOCATION=us-central
     ```
 
@@ -182,13 +181,12 @@ Autoscaler infrastructure, with the exception of Cloud Scheduler, lives.
 
 ### Deploying the Autoscaler
 
-1.  Set the project ID, region, zone and App Engine location in the
+1.  Set the project ID, region, and App Engine location in the
     corresponding Terraform environment variables
 
     ```sh
     export TF_VAR_project_id="${AUTOSCALER_PROJECT_ID}"
     export TF_VAR_region="${AUTOSCALER_REGION}"
-    export TF_VAR_zone="${AUTOSCALER_ZONE}"
     export TF_VAR_location="${AUTOSCALER_APP_ENGINE_LOCATION}"
     ```
 
@@ -231,13 +229,12 @@ topic and function in the project where the Spanner instances live.
     gcloud config set project "${APP_PROJECT_ID}"
     ```
 
-4.  Choose the [region and zone][region-and-zone] and
+4.  Choose the [region][region-and-zone] and
     [App Engine Location][app-engine-location] where the Application project
     will be located.
 
     ```sh
     export APP_REGION=us-central1
-    export APP_ZONE=us-central1-c
     export APP_APP_ENGINE_LOCATION=us-central
     ```
 
@@ -265,13 +262,12 @@ topic and function in the project where the Spanner instances live.
 
 ### Deploy the Application infrastructure
 
-1.  Set the project ID, region, zone and App Engine location in the
+1.  Set the project ID, region, and App Engine location in the
     corresponding Terraform environment variables
 
     ```sh
     export TF_VAR_project_id="${APP_PROJECT_ID}"
     export TF_VAR_region="${APP_REGION}"
-    export TF_VAR_zone="${APP_ZONE}"
     export TF_VAR_location="${APP_APP_ENGINE_LOCATION}"
     ```
 
@@ -377,7 +373,6 @@ topic and function in the project where the Spanner instances live.
 
     export TF_VAR_project_id="${AUTOSCALER_PROJECT_ID}"
     export TF_VAR_region="${AUTOSCALER_REGION}"
-    export TF_VAR_zone="${AUTOSCALER_ZONE}"
     export TF_VAR_location="${AUTOSCALER_APP_ENGINE_LOCATION}"
     ```
 

--- a/terraform/cloud-functions/distributed/app-project/main.tf
+++ b/terraform/cloud-functions/distributed/app-project/main.tf
@@ -26,7 +26,6 @@ terraform {
 provider "google" {
   project = var.project_id
   region  = var.region
-  zone    = var.zone
 }
 
 data "terraform_remote_state" "autoscaler" {

--- a/terraform/cloud-functions/distributed/app-project/variables.tf
+++ b/terraform/cloud-functions/distributed/app-project/variables.tf
@@ -22,10 +22,6 @@ variable "region" {
   type = string
 }
 
-variable "zone" {
-  type = string
-}
-
 variable "spanner_name" {
   type    = string
   default = "autoscale-test"

--- a/terraform/cloud-functions/distributed/autoscaler-project/main.tf
+++ b/terraform/cloud-functions/distributed/autoscaler-project/main.tf
@@ -26,7 +26,6 @@ terraform {
 provider "google" {
   project = var.project_id
   region  = var.region
-  zone    = var.zone
 }
 
 resource "google_service_account" "poller_sa" {

--- a/terraform/cloud-functions/distributed/autoscaler-project/variables.tf
+++ b/terraform/cloud-functions/distributed/autoscaler-project/variables.tf
@@ -22,10 +22,6 @@ variable "region" {
   type = string
 }
 
-variable "zone" {
-  type = string
-}
-
 variable "forwarder_sa_emails" {
   type = list(string)
   // Example ["serviceAccount:forwarder_sa@app-project.iam.gserviceaccount.com"]

--- a/terraform/cloud-functions/per-project/README.md
+++ b/terraform/cloud-functions/per-project/README.md
@@ -130,13 +130,12 @@ In this section you prepare your project for deployment.
     gcloud config set project "${PROJECT_ID}"
     ```
 
-4.  Choose the [region and zone][region-and-zone] and
+4.  Choose the [region][region-and-zone] and
     [App Engine Location][app-engine-location] where the Autoscaler
     infrastructure will be located.
 
     ```sh
     export REGION=us-central1
-    export ZONE=us-central1-c
     export APP_ENGINE_LOCATION=us-central
     ```
 
@@ -177,13 +176,12 @@ In this section you prepare your project for deployment.
 
 ## Deploying the Autoscaler
 
-1.  Set the project ID, region and zone in the corresponding Terraform
+1.  Set the project ID and region in the corresponding Terraform
     environment variables
 
     ```sh
     export TF_VAR_project_id="${PROJECT_ID}"
     export TF_VAR_region="${REGION}"
-    export TF_VAR_zone="${ZONE}"
     ```
 
 2.  If you want to create a new Spanner instance for testing the Autoscaler, set

--- a/terraform/cloud-functions/per-project/main.tf
+++ b/terraform/cloud-functions/per-project/main.tf
@@ -26,7 +26,6 @@ terraform {
 provider "google" {
   project = var.project_id
   region  = var.region
-  zone    = var.zone
 }
 
 resource "google_service_account" "poller_sa" {

--- a/terraform/cloud-functions/per-project/variables.tf
+++ b/terraform/cloud-functions/per-project/variables.tf
@@ -22,10 +22,6 @@ variable "region" {
   type = string
 }
 
-variable "zone" {
-  type = string
-}
-
 variable "spanner_name" {
   type    = string
   default = "autoscale-test"

--- a/terraform/gke/decoupled/main.tf
+++ b/terraform/gke/decoupled/main.tf
@@ -30,13 +30,11 @@ terraform {
 provider "google" {
   project = var.project_id
   region  = var.region
-  zone    = var.zone
 }
 
 provider "google-beta" {
   project = var.project_id
   region  = var.region
-  zone    = var.zone
 }
 
 resource "google_service_account" "poller_sa" {

--- a/terraform/gke/decoupled/variables.tf
+++ b/terraform/gke/decoupled/variables.tf
@@ -22,10 +22,6 @@ variable "region" {
   type = string
 }
 
-variable "zone" {
-  type = string
-}
-
 variable "spanner_name" {
   type    = string
   default = "autoscale-test"

--- a/terraform/gke/unified/main.tf
+++ b/terraform/gke/unified/main.tf
@@ -30,13 +30,11 @@ terraform {
 provider "google" {
   project = var.project_id
   region  = var.region
-  zone    = var.zone
 }
 
 provider "google-beta" {
   project = var.project_id
   region  = var.region
-  zone    = var.zone
 }
 
 resource "google_service_account" "autoscaler_sa" {

--- a/terraform/gke/unified/variables.tf
+++ b/terraform/gke/unified/variables.tf
@@ -22,10 +22,6 @@ variable "region" {
   type = string
 }
 
-variable "zone" {
-  type = string
-}
-
 variable "spanner_name" {
   type    = string
   default = "autoscale-test"


### PR DESCRIPTION
The `zone` parameter is no longer directly used and only supplied as a parameter to the provider for a default value.