### PR TITLE
feat!: Remove support for node v16

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v4

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,23 @@
 {
-  "name": "autoscaler",
+  "name": "cloudspannerecosystem/autoscaler",
+  "version": "1.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "cloudspannerecosystem/autoscaler",
+      "version": "1.20.0",
+      "license": "Apache-2.0",
       "devDependencies": {
         "@types/mocha": "^10.0.6",
         "eslint": "^8.57.0",
         "eslint-config-google": "^0.14.0",
         "markdownlint-cli": "^0.39.0",
         "typescript": "^5.4.2"
+      },
+      "engines": {
+        "node": "^18.22.0 || >=20.5.0",
+        "npm": "^10.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "Description": "Autoscaling for Cloud Spanner based on CPU metrics",
   "homepage": "https://github.com/cloudspannerecosystem/autoscaler",
   "license": "Apache-2.0",
+  "author": "Google Inc.",
   "scripts": {
     "eslint": "eslint .",
     "eslint-fix": "eslint --fix .",
@@ -17,5 +18,9 @@
     "eslint-config-google": "^0.14.0",
     "markdownlint-cli": "^0.39.0",
     "typescript": "^5.4.2"
+  },
+  "engines": {
+    "node": ">=18.0.0 || >=20.0.0",
+    "npm":  ">=10.0.0"
   }
 }

--- a/src/.npmrc
+++ b/src/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -12,6 +12,10 @@
         "js-yaml": "^4.1.0",
         "poller-core": "file:poller/poller-core",
         "scaler-core": "file:scaler/scaler-core"
+      },
+      "engines": {
+        "node": "^18.22.0 || >=20.5.0",
+        "npm": "^10.0.0"
       }
     },
     "autoscaler-common": {

--- a/src/package.json
+++ b/src/package.json
@@ -12,5 +12,9 @@
   },
   "scripts": {
     "start": "node -e \"require('./index').autoscalerMain()\""
+  },
+  "engines": {
+    "node": ">=18.0.0 || >=20.0.0",
+    "npm":  ">=10.0.0"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Node v16 has been end-of-life since 2023-09-11, so testing is removed for this version of Node.

Added node version enforcement to package.json.