### PR TITLE
Switch off newly defaulted deletion protection

### DIFF
--- a/terraform/modules/autoscaler-cluster/main.tf
+++ b/terraform/modules/autoscaler-cluster/main.tf
@@ -180,6 +180,7 @@ module "cluster" {
 
   remove_default_node_pool = true
   initial_node_count       = 1
+  deletion_protection      = false
 
   master_authorized_networks = [
     {


### PR DESCRIPTION
Recent versions of the [Google Terraform GKE module](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/) enable cluster deletion protection by default, which we do not want.