### PR TITLE
fix: Correctly log Exceptions

### DIFF
--- a/src/autoscaler-common/counters_base.js
+++ b/src/autoscaler-common/counters_base.js
@@ -456,8 +456,8 @@ async function tryFlush() {
         `Failed to flush counters after ${EXPORTER_PARAMETERS[exporterMode].FLUSH_MAX_ATTEMPTS} attempts - see OpenTelemetry logging`,
       );
     }
-  } catch (e) {
-    logger.error('Error while flushing counters', e);
+  } catch (err) {
+    logger.error({err: err, message: `Error while flushing counters: ${err}`});
   } finally {
     // Release any waiters...
     flushInProgress.resolve(null);

--- a/src/autoscaler-common/logger.js
+++ b/src/autoscaler-common/logger.js
@@ -48,6 +48,7 @@ const loggingBunyan = new LoggingBunyan({
 const logger = bunyan.createLogger({
   name: 'cloud-spanner-autoscaler',
   streams: [loggingBunyan.stream(getLogLevel())],
+  serializers: bunyan.stdSerializers,
 });
 
 module.exports = {

--- a/src/forwarder/index.js
+++ b/src/forwarder/index.js
@@ -64,11 +64,11 @@ async function forwardFromHTTP(req, res) {
     res.status(200).end();
   } catch (err) {
     logger.error({
-      message: `An error occurred in the Autoscaler forwarder (HTTP)`,
+      message: `An error occurred in the Autoscaler forwarder (HTTP): ${err}`,
       err: err,
+      payload: payloadString,
     });
-    logger.error({message: `JSON payload`, payload: payloadString});
-    res.status(500).end(err instanceof Object ? err.toString() : err);
+    res.status(500).end('An exception occurred');
   }
 }
 
@@ -96,10 +96,10 @@ async function forwardFromPubSub(pubSubEvent, context) {
     });
   } catch (err) {
     logger.error({
-      message: `An error occurred in the Autoscaler forwarder (PubSub)`,
+      message: `An error occurred in the Autoscaler forwarder (PubSub): ${err}`,
       err: err,
+      payload: payload,
     });
-    logger.error({message: `JSON payload`, payload: payload});
   }
 }
 

--- a/src/poller/index.js
+++ b/src/poller/index.js
@@ -51,7 +51,7 @@ async function main() {
     );
   } catch (err) {
     logger.error({
-      message: 'Error in Poller wrapper:',
+      message: `Error in Poller: ${err}`,
       err: err,
     });
   }

--- a/src/scaler/index.js
+++ b/src/scaler/index.js
@@ -41,7 +41,7 @@ function main() {
     app.listen(port);
   } catch (err) {
     logger.error({
-      message: 'Error in Scaler wrapper:',
+      message: 'Error startting Scaler: ${err}',
       err: err,
     });
   }

--- a/src/scaler/scaler-core/index.js
+++ b/src/scaler/scaler-core/index.js
@@ -347,17 +347,11 @@ async function processScalingRequest(spanner, autoscalerState) {
         await Counters.incScalingSuccessCounter(spanner, suggestedSize);
       } catch (err) {
         logger.error({
-          message: `----- ${spanner.projectId}/${spanner.instanceId}: Unsuccessful scaling attempt.`,
-          projectId: spanner.projectId,
-          instanceId: spanner.instanceId,
-          payload: err,
-          err: err,
-        });
-        logger.error({
-          message: `----- ${spanner.projectId}/${spanner.instanceId}: Spanner payload:`,
+          message: `----- ${spanner.projectId}/${spanner.instanceId}: Unsuccessful scaling attempt: ${err}`,
           projectId: spanner.projectId,
           instanceId: spanner.instanceId,
           payload: spanner,
+          err: err,
         });
         eventType = 'SCALING_FAILURE';
         await Counters.incScalingFailedCounter(spanner, suggestedSize);
@@ -414,22 +408,17 @@ async function scaleSpannerInstancePubSub(pubSubEvent, context) {
       await Counters.incRequestsSuccessCounter();
     } catch (err) {
       logger.error({
-        message: `Failed to process scaling request\n`,
+        message: `Failed to process scaling request: ${err}`,
         projectId: spanner.projectId,
         instanceId: spanner.instanceId,
         payload: spanner,
-      });
-      logger.error({
-        message: `Exception\n`,
-        projectId: spanner.projectId,
-        instanceId: spanner.instanceId,
         err: err,
       });
       await Counters.incRequestsFailedCounter();
     }
   } catch (err) {
     logger.error({
-      message: `Failed to parse pubSub scaling request\n`,
+      message: `Failed to parse pubSub scaling request: ${err}`,
       payload: pubSubEvent.data,
       err: err,
     });
@@ -461,13 +450,17 @@ async function scaleSpannerInstanceHTTP(req, res) {
       res.status(200).end();
       await Counters.incRequestsSuccessCounter();
     } catch (err) {
-      console.error(err);
+      logger.error({
+        message: `Failed to process scaling request: ${err}`,
+        payload: payload,
+        err: err,
+      });
       res.status(500).contentType('text/plain').end('An Exception occurred');
       await Counters.incRequestsFailedCounter();
     }
   } catch (err) {
     logger.error({
-      message: `Failed to parse http scaling request\n`,
+      message: `Failed to parse http scaling request: ${err}`,
       err: err,
     });
     await Counters.incRequestsFailedCounter();
@@ -496,16 +489,10 @@ async function scaleSpannerInstanceJSON(req, res) {
     await Counters.incRequestsSuccessCounter();
   } catch (err) {
     logger.error({
-      message: `Failed to process scaling request\n`,
+      message: `Failed to process scaling request: ${err}`,
       projectId: spanner.projectId,
       instanceId: spanner.instanceId,
       payload: spanner,
-    });
-    logger.error({
-      message: `Exception\n`,
-      projectId: spanner.projectId,
-      instanceId: spanner.instanceId,
-      payload: err,
       err: err,
     });
     res.status(500).contentType('text/plain').end('An Exception occurred');
@@ -531,16 +518,10 @@ async function scaleSpannerInstanceLocal(spanner) {
     await Counters.incRequestsSuccessCounter();
   } catch (err) {
     logger.error({
-      message: `Failed to process scaling request\n`,
+      message: `Failed to process scaling request: ${err}`,
       projectId: spanner.projectId,
       instanceId: spanner.instanceId,
       payload: spanner,
-    });
-    logger.error({
-      message: `Exception\n`,
-      projectId: spanner.projectId,
-      instanceId: spanner.instanceId,
-      payload: err,
       err: err,
     });
   } finally {

--- a/src/scaler/scaler-core/state.js
+++ b/src/scaler/scaler-core/state.js
@@ -476,8 +476,11 @@ class StateFirestore extends State {
         await oldDocRef.delete();
       }
       return snapshot;
-    } catch (e) {
-      logger.error(e, `Failed to migrate docpaths`);
+    } catch (err) {
+      logger.error({
+        message: `Failed to migrate docpaths: ${err}`,
+        err: err,
+      });
     }
     return null;
   }

--- a/src/scaler/scaler-core/utils.js
+++ b/src/scaler/scaler-core/utils.js
@@ -118,7 +118,7 @@ async function publishProtoMsgDownstream(eventName, jsonData, topicId) {
     )
     .catch((err) => {
       logger.error({
-        message: `An error occurred publishing ${eventName} message downstream to topic: ${topicId}`,
+        message: `An error occurred publishing ${eventName} message downstream to topic: ${topicId}: ${err}`,
         err: err,
       });
     });

--- a/src/unifiedScaler.js
+++ b/src/unifiedScaler.js
@@ -63,7 +63,7 @@ async function main() {
     }
   } catch (err) {
     logger.error({
-      message: 'Error in unified poller/scaler wrapper:',
+      message: 'Error in unified poller/scaler wrapper: ${err}',
       err: err,
     });
   } finally {


### PR DESCRIPTION
Adds bunyan Error serializer (to log {err:err} correctly with stack trace etc. Fix log messages to include error message in log message

Before: exception stack traces were not included in logging: 

```js
err=new Error('myerror');
logger.error({err:err, message:`Failed`});
{
  "timestamp": {
    "seconds": 1712143463,
    "nanos": 476000070
  },
  "severity": "ERROR",
  "logging.googleapis.com/insertId": "..........5RSfIdnw_0SuufwA49eSIJ",
  "name": "redis-cluster-autoscaler",
  "hostname": "dastardly.c.googlers.com",
  "pid": 208009,
  "level": 50,
  "err": {},
  "message": "Failed",
  "msg": "myerror",
  "time": "2024-04-03T11:24:23.476Z",
  "v": 0,
  "logName": "projects/redis-autoscaler/logs/redis-cluster-autoscaler"
}
```
After, includes err object correctly with stack trace
```js
err=new Error('myerror');
logger.error({err:err, message:Failed: ${err}});
{
  "timestamp": {
    "seconds": 1712143548,
    "nanos": 480999946
  },
  "severity": "ERROR",
  "logging.googleapis.com/insertId": "..........E5w78.D4S4fuorMiE2SJ3e",
  "name": "redis-cluster-autoscaler",
  "hostname": "dastardly.c.googlers.com",
  "pid": 208429,
  "level": 50,
  "err": {
    "message": "myerror",
    "name": "Error",
    "stack": "Error: myerror\n    at REPL3:1:5\n    at Script.runInThisContext (node:vm:122:12)\n    at REPLServer.defaultEval (node:repl:594:29)\n    at bound (node:domain:433:15)\n    at REPLServer.runBound [as eval] (node:domain:444:12)\n    at REPLServer.onLine (node:repl:924:10)\n    at REPLServer.emit (node:events:529:35)\n    at REPLServer.emit (node:domain:489:12)\n    at [_onLine] [as _onLine] (node:internal/readline/interface:423:12)\n    at [_line] [as _line] (node:internal/readline/interface:894:18)"
  },
  "message": "Failed: Error: myerror",
  "msg": "myerror",
  "time": "2024-04-03T11:25:48.481Z",
  "v": 0,
  "logName": "projects/redis-autoscaler/logs/redis-cluster-autoscaler"
}
```