### PR TITLE
fix: Remove zone parameter

### DIFF
--- a/terraform/cloud-functions/per-project/test/per_project_e2e_test.go
+++ b/terraform/cloud-functions/per-project/test/per_project_e2e_test.go
@@ -146,7 +146,6 @@ func TestPerProjectEndToEndDeployment(t *testing.T) {
 			Vars: map[string]interface{}{
 				"project_id":                    config.ProjectId,
 				"region":                        "us-central1",
-				"zone":                          "us-central1-a",
 				"spanner_name":                  spannerName,
 				"terraform_spanner_test":        true,
 				"spanner_test_processing_units": spannerTestProcessingUnits,


### PR DESCRIPTION
This is no longer required by the underlying Terraform.