### PR TITLE
feat: Add metric for scaling duration

### DIFF
--- a/src/poller/README.md
+++ b/src/poller/README.md
@@ -316,7 +316,7 @@ data:
       units: NODES
       minSize: 5
       maxSize: 30
-      scalingMethod DIRECT
+      scalingMethod: DIRECT
     - projectId: spanner-autoscaler-test
       instanceId: spanner-scaling-threshold
       units: PROCESSING_UNITS
@@ -331,7 +331,7 @@ data:
       units: NODES
       minSize: 5
       maxSize: 30
-      scalingMethod LINEAR
+      scalingMethod: LINEAR
       scaleInLimit: 25
       metrics:
       - name: my_custom_metric

--- a/src/poller/README.md
+++ b/src/poller/README.md
@@ -216,8 +216,8 @@ If the value of `name` is `spanner`, the following values are required.
 | `instanceId`               | The instance id of Cloud Spanner which you want to manage the state. |
 | `databaseId`               | The database id of Cloud Spanner instance which you want to manage the state. |
 
-When using Cloud Spanner to manage the state,
-a table with the following DDL is created at runtime.
+When using Cloud Spanner to manage the state, a table with the following DDL is
+created at runtime.
 
 ```sql
 CREATE TABLE spannerAutoscaler (
@@ -227,15 +227,30 @@ CREATE TABLE spannerAutoscaler (
   updatedOn TIMESTAMP,
   lastScalingCompleteTimestamp TIMESTAMP,
   scalingOperationId STRING(MAX),
+  scalingRequestedSize INT64,
+  scalingMethod STRING(MAX),
+  scalingPreviousSize INT64,
 ) PRIMARY KEY (id)
 ```
 
-Note: If you are upgrading from V1, then you need to add the 2 new columns to the
-spanner schema using the following DDL statements
+Note: If you are upgrading from v1.x, then you need to add the 5 new columns to
+the spanner schema using the following DDL statements
 
 ```sql
 ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS lastScalingCompleteTimestamp TIMESTAMP;
 ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingOperationId STRING(MAX);
+ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingRequestedSize INT64;
+ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingMethod STRING(MAX);
+ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingPreviousSize INT64;
+```
+
+Note: If you are upgrading from V2.0.x, then you need to add the 3 new columns
+to the spanner schema using the following DDL statements
+
+```sql
+ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingRequestedSize INT64;
+ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingMethod STRING(MAX);
+ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingPreviousSize INT64;
 ```
 
 ## Example configuration for Cloud Functions
@@ -301,7 +316,7 @@ data:
       units: NODES
       minSize: 5
       maxSize: 30
-      scalingMethod: DIRECT
+      scalingMethod DIRECT
     - projectId: spanner-autoscaler-test
       instanceId: spanner-scaling-threshold
       units: PROCESSING_UNITS
@@ -316,7 +331,7 @@ data:
       units: NODES
       minSize: 5
       maxSize: 30
-      scalingMethod: LINEAR
+      scalingMethod LINEAR
       scaleInLimit: 25
       metrics:
       - name: my_custom_metric

--- a/src/scaler/scaler-core/test/state.test.js
+++ b/src/scaler/scaler-core/test/state.test.js
@@ -139,6 +139,9 @@ describe('stateFirestoreTests', () => {
         lastScalingTimestamp: DUMMY_FIRESTORE_TIMESTAMP,
         lastScalingCompleteTimestamp: DUMMY_FIRESTORE_TIMESTAMP,
         scalingOperationId: null,
+        scalingRequestedSize: null,
+        scalingMethod: null,
+        scalingPreviousSize: null,
       };
     },
   };
@@ -226,6 +229,9 @@ describe('stateFirestoreTests', () => {
       lastScalingTimestamp: DUMMY_TIMESTAMP,
       lastScalingCompleteTimestamp: DUMMY_TIMESTAMP,
       scalingOperationId: null,
+      scalingRequestedSize: null,
+      scalingMethod: null,
+      scalingPreviousSize: null,
     });
   });
 
@@ -247,6 +253,9 @@ describe('stateFirestoreTests', () => {
       updatedOn: DUMMY_TIMESTAMP,
       lastScalingCompleteTimestamp: 0,
       scalingOperationId: null,
+      scalingRequestedSize: null,
+      scalingMethod: null,
+      scalingPreviousSize: null,
     };
 
     const expectedDoc = {
@@ -255,6 +264,9 @@ describe('stateFirestoreTests', () => {
       lastScalingTimestamp: firestore.Timestamp.fromMillis(0),
       lastScalingCompleteTimestamp: firestore.Timestamp.fromMillis(0),
       scalingOperationId: null,
+      scalingRequestedSize: null,
+      scalingMethod: null,
+      scalingPreviousSize: null,
     };
 
     sinon.assert.calledTwice(stubFirestoreInstance.doc);
@@ -291,6 +303,9 @@ describe('stateFirestoreTests', () => {
       updatedOn: DUMMY_TIMESTAMP,
       lastScalingCompleteTimestamp: DUMMY_TIMESTAMP,
       scalingOperationId: null,
+      scalingRequestedSize: null,
+      scalingMethod: null,
+      scalingPreviousSize: null,
     };
 
     sinon.assert.calledTwice(stubFirestoreInstance.doc);
@@ -335,6 +350,9 @@ describe('stateFirestoreTests', () => {
       lastScalingTimestamp: DUMMY_FIRESTORE_TIMESTAMP2,
       lastScalingCompleteTimestamp: DUMMY_FIRESTORE_TIMESTAMP,
       scalingOperationId: null,
+      scalingRequestedSize: null,
+      scalingMethod: null,
+      scalingPreviousSize: null,
     });
   });
 });
@@ -366,6 +384,9 @@ describe('stateSpannerTests', () => {
       'updatedOn',
       'lastScalingCompleteTimestamp',
       'scalingOperationId',
+      'scalingRequestedSize',
+      'scalingPreviousSize',
+      'scalingMethod',
     ],
     keySet: {
       keys: [
@@ -388,6 +409,9 @@ describe('stateSpannerTests', () => {
         updatedOn: new Date(DUMMY_TIMESTAMP),
         lastScalingCompleteTimestamp: new Date(DUMMY_TIMESTAMP),
         scalingOperationId: null,
+        scalingRequestedSize: null,
+        scalingMethod: null,
+        scalingPreviousSize: null,
       };
     },
   };
@@ -517,13 +541,17 @@ describe('stateSpannerTests', () => {
     const state = State.buildFor(autoscalerConfig);
     const data = await state.get();
 
-    sinon.assert.calledWith(stubSpannerTable.read, expectedQuery);
+    assert.equals(stubSpannerTable.read.callCount, 1);
+    assert.equals(stubSpannerTable.read.args[0][0], expectedQuery);
     assert.equals(data, {
       createdOn: DUMMY_TIMESTAMP,
       updatedOn: DUMMY_TIMESTAMP,
       lastScalingTimestamp: DUMMY_TIMESTAMP,
       lastScalingCompleteTimestamp: DUMMY_TIMESTAMP,
       scalingOperationId: null,
+      scalingRequestedSize: null,
+      scalingPreviousSize: null,
+      scalingMethod: null,
     });
   });
 
@@ -539,12 +567,16 @@ describe('stateSpannerTests', () => {
 
     const data = await state.get();
 
-    sinon.assert.calledWith(stubSpannerTable.upsert, {
+    assert.equals(stubSpannerTable.upsert.callCount, 1);
+    assert.equals(stubSpannerTable.upsert.args[0][0], {
       lastScalingTimestamp: SPANNER_EPOCH_ISO_TIME,
       createdOn: DUMMY_SPANNER_ISO_TIME,
       updatedOn: DUMMY_SPANNER_ISO_TIME,
       lastScalingCompleteTimestamp: SPANNER_EPOCH_ISO_TIME,
       scalingOperationId: null,
+      scalingRequestedSize: null,
+      scalingPreviousSize: null,
+      scalingMethod: null,
       id: expectedRowId,
     });
 
@@ -554,6 +586,9 @@ describe('stateSpannerTests', () => {
       createdOn: DUMMY_TIMESTAMP,
       updatedOn: DUMMY_TIMESTAMP,
       scalingOperationId: null,
+      scalingRequestedSize: null,
+      scalingMethod: null,
+      scalingPreviousSize: null,
     });
   });
 
@@ -575,6 +610,99 @@ describe('stateSpannerTests', () => {
     await state.updateState(doc);
 
     sinon.assert.calledWith(stubSpannerTable.upsert, {
+      updatedOn: DUMMY_SPANNER_ISO_TIME2,
+      lastScalingTimestamp: DUMMY_SPANNER_ISO_TIME2,
+      lastScalingCompleteTimestamp: DUMMY_SPANNER_ISO_TIME,
+      scalingOperationId: null,
+      scalingRequestedSize: null,
+      scalingMethod: null,
+      scalingPreviousSize: null,
+      id: expectedRowId,
+    });
+  });
+
+  it('get() should retry without newSchemaCols when ColumnNotFound', async function () {
+    const expectedQueryWithNoNewCols = {
+      ...expectedQuery,
+      columns: [
+        'lastScalingTimestamp',
+        'createdOn',
+        'updatedOn',
+        'lastScalingCompleteTimestamp',
+        'scalingOperationId',
+      ],
+    };
+
+    stubSpannerTable.read
+      .onCall(0)
+      // @ts-ignore
+      .rejects(
+        new Error('5 NOT_FOUND Column not found in table stateTable: someCol'),
+      );
+    // @ts-ignore
+    stubSpannerTable.read.onCall(1).resolves([[VALID_ROW]]);
+
+    const state = State.buildFor(autoscalerConfig);
+    // make state.now return a fixed value
+    const nowfunc = sinon.stub();
+    sinon.replaceGetter(state, 'now', nowfunc);
+    nowfunc.returns(DUMMY_TIMESTAMP);
+
+    const data = await state.get();
+
+    assert.equals(stubSpannerTable.read.callCount, 2);
+    assert.equals(stubSpannerTable.read.args[0][0], expectedQuery);
+    assert.equals(stubSpannerTable.read.args[1][0], expectedQueryWithNoNewCols);
+
+    assert.equals(data, {
+      createdOn: DUMMY_TIMESTAMP,
+      updatedOn: DUMMY_TIMESTAMP,
+      lastScalingTimestamp: DUMMY_TIMESTAMP,
+      lastScalingCompleteTimestamp: DUMMY_TIMESTAMP,
+      scalingOperationId: null,
+      scalingRequestedSize: null,
+      scalingPreviousSize: null,
+      scalingMethod: null,
+    });
+  });
+
+  it('updateState() should retry without newSchemaCols when ColumnNotFound', async function () {
+    // @ts-ignore
+    stubSpannerTable.read.returns(Promise.resolve([[VALID_ROW]]));
+    stubSpannerTable.upsert
+      .onCall(0)
+      // @ts-ignore
+      .rejects(
+        new Error('5 NOT_FOUND Column not found in table stateTable: someCol'),
+      );
+    // @ts-ignore
+    stubSpannerTable.upsert.onCall(1).resolves();
+
+    const state = State.buildFor(autoscalerConfig);
+
+    // make state.now return a fixed value
+    const nowfunc = sinon.stub();
+    sinon.replaceGetter(state, 'now', nowfunc);
+    nowfunc.returns(DUMMY_TIMESTAMP);
+
+    const doc = await state.get();
+
+    nowfunc.returns(DUMMY_TIMESTAMP2);
+    doc.lastScalingTimestamp = DUMMY_TIMESTAMP2;
+    await state.updateState(doc);
+
+    assert.equals(stubSpannerTable.upsert.callCount, 2);
+    assert.equals(stubSpannerTable.upsert.args[0][0], {
+      updatedOn: DUMMY_SPANNER_ISO_TIME2,
+      lastScalingTimestamp: DUMMY_SPANNER_ISO_TIME2,
+      lastScalingCompleteTimestamp: DUMMY_SPANNER_ISO_TIME,
+      scalingOperationId: null,
+      scalingRequestedSize: null,
+      scalingMethod: null,
+      scalingPreviousSize: null,
+      id: expectedRowId,
+    });
+    assert.equals(stubSpannerTable.upsert.args[1][0], {
       updatedOn: DUMMY_SPANNER_ISO_TIME2,
       lastScalingTimestamp: DUMMY_SPANNER_ISO_TIME2,
       lastScalingCompleteTimestamp: DUMMY_SPANNER_ISO_TIME,

--- a/src/scaler/scaler-core/test/test-utils.js
+++ b/src/scaler/scaler-core/test/test-utils.js
@@ -61,6 +61,9 @@ function createStateData() {
     updatedOn: 0,
     lastScalingCompleteTimestamp: 0,
     scalingOperationId: null,
+    scalingMethod: null,
+    scalingPreviousSize: null,
+    scalingRequestedSize: null,
   };
 }
 

--- a/terraform/cloud-functions/distributed/README.md
+++ b/terraform/cloud-functions/distributed/README.md
@@ -333,21 +333,36 @@ topic and function in the project where the Spanner instances live.
 
     ```sql
     CREATE TABLE spannerAutoscaler (
-       id STRING(MAX),
-       lastScalingTimestamp TIMESTAMP,
-       createdOn TIMESTAMP,
-       updatedOn TIMESTAMP,
-       lastScalingCompleteTimestamp TIMESTAMP,
-       scalingOperationId STRING(MAX),
+      id STRING(MAX),
+      lastScalingTimestamp TIMESTAMP,
+      createdOn TIMESTAMP,
+      updatedOn TIMESTAMP,
+      lastScalingCompleteTimestamp TIMESTAMP,
+      scalingOperationId STRING(MAX),
+      scalingRequestedSize INT64,
+      scalingMethod STRING(MAX),
+      scalingPreviousSize INT64,
     ) PRIMARY KEY (id)
     ```
 
-    If you are upgrading from V1, then you need to add the 2 new columns to the
-    existing spanner schema using the following DDL statements
+    Note: If you are upgrading from v1.x, then you need to add the 5 new columns
+    to the spanner schema using the following DDL statements
 
     ```sql
     ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS lastScalingCompleteTimestamp TIMESTAMP;
     ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingOperationId STRING(MAX);
+    ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingRequestedSize INT64;
+    ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingMethod STRING(MAX);
+    ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingPreviousSize INT64;
+    ```
+
+    Note: If you are upgrading from V2.0.x, then you need to add the 3 new columns
+    to the spanner schema using the following DDL statements
+
+    ```sql
+    ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingRequestedSize INT64;
+    ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingMethod STRING(MAX);
+    ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingPreviousSize INT64;
     ```
 
     For more information on how to make your existing Spanner instance to be

--- a/terraform/cloud-functions/per-project/README.md
+++ b/terraform/cloud-functions/per-project/README.md
@@ -234,21 +234,36 @@ In this section you prepare your project for deployment.
 
     ```sql
     CREATE TABLE spannerAutoscaler (
-       id STRING(MAX),
-       lastScalingTimestamp TIMESTAMP,
-       createdOn TIMESTAMP,
-       updatedOn TIMESTAMP,
-       lastScalingCompleteTimestamp TIMESTAMP,
-       scalingOperationId STRING(MAX),
+      id STRING(MAX),
+      lastScalingTimestamp TIMESTAMP,
+      createdOn TIMESTAMP,
+      updatedOn TIMESTAMP,
+      lastScalingCompleteTimestamp TIMESTAMP,
+      scalingOperationId STRING(MAX),
+      scalingRequestedSize INT64,
+      scalingMethod STRING(MAX),
+      scalingPreviousSize INT64,
     ) PRIMARY KEY (id)
     ```
 
-    If you are upgrading from V1, then you need to add the 2 new columns to the
-    existing spanner schema using the following DDL statements
+    Note: If you are upgrading from v1.x, then you need to add the 5 new columns
+    to the spanner schema using the following DDL statements
 
     ```sql
     ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS lastScalingCompleteTimestamp TIMESTAMP;
     ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingOperationId STRING(MAX);
+    ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingRequestedSize INT64;
+    ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingMethod STRING(MAX);
+    ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingPreviousSize INT64;
+    ```
+
+    Note: If you are upgrading from V2.0.x, then you need to add the 3 new columns
+    to the spanner schema using the following DDL statements
+
+    ```sql
+    ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingRequestedSize INT64;
+    ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingMethod STRING(MAX);
+    ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingPreviousSize INT64;
     ```
 
     For more information on how to make your existing Spanner instance to be

--- a/terraform/gke/README.md
+++ b/terraform/gke/README.md
@@ -327,21 +327,36 @@ In this section you prepare your project for deployment.
 
     ```sql
     CREATE TABLE spannerAutoscaler (
-       id STRING(MAX),
-       lastScalingTimestamp TIMESTAMP,
-       createdOn TIMESTAMP,
-       updatedOn TIMESTAMP,
-       lastScalingCompleteTimestamp TIMESTAMP,
-       scalingOperationId STRING(MAX),
+      id STRING(MAX),
+      lastScalingTimestamp TIMESTAMP,
+      createdOn TIMESTAMP,
+      updatedOn TIMESTAMP,
+      lastScalingCompleteTimestamp TIMESTAMP,
+      scalingOperationId STRING(MAX),
+      scalingRequestedSize INT64,
+      scalingMethod STRING(MAX),
+      scalingPreviousSize INT64,
     ) PRIMARY KEY (id)
     ```
 
-    If you are upgrading from V1, then you need to add the 2 new columns to the
-    existing spanner schema using the following DDL statements
+    Note: If you are upgrading from v1.x, then you need to add the 5 new columns
+    to the spanner schema using the following DDL statements
 
     ```sql
     ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS lastScalingCompleteTimestamp TIMESTAMP;
     ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingOperationId STRING(MAX);
+    ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingRequestedSize INT64;
+    ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingMethod STRING(MAX);
+    ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingPreviousSize INT64;
+    ```
+
+    Note: If you are upgrading from V2.0.x, then you need to add the 3 new columns
+    to the spanner schema using the following DDL statements
+
+    ```sql
+    ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingRequestedSize INT64;
+    ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingMethod STRING(MAX);
+    ALTER TABLE spannerAutoscaler ADD COLUMN IF NOT EXISTS scalingPreviousSize INT64;
     ```
 
 2.  Next, continue to [Creating Autoscaler infrastructure](#creating-autoscaler-infrastructure).

--- a/terraform/modules/spanner/main.tf
+++ b/terraform/modules/spanner/main.tf
@@ -120,6 +120,9 @@ resource "google_spanner_database" "state-database" {
       updatedOn TIMESTAMP,
       lastScalingCompleteTimestamp TIMESTAMP,
       scalingOperationId STRING(MAX),
+      scalingRequestedSize INT64,
+      scalingMethod STRING(MAX),
+      scalingPreviousSize INT64,
     ) PRIMARY KEY (id)
     EOT
   ]


### PR DESCRIPTION
Adds a distribution metric for scaling duration, and only records success once operation is complete

Requires an update to the spanner schema to correctly apply metric parametes.