### PR TITLE
feat: Take into account number of databases in an instance

### DIFF
--- a/src/autoscaler-common/types.js
+++ b/src/autoscaler-common/types.js
@@ -25,6 +25,7 @@ const AutoscalerUnits = {
  *    currentSize: number,
  *    regional: boolean,
  *    currentNodes: number,
+ *    currentNumDatabases: number,
  *  }} SpannerMetadata
  */
 

--- a/src/scaler/README.md
+++ b/src/scaler/README.md
@@ -130,6 +130,7 @@ The following is an example:
       }
    ],
    "currentSize":100,
+   "currentNumDatabases": 10,
    "regional":true
 }
 ```

--- a/src/scaler/scaler-core/test/scaling-methods/base.test.js
+++ b/src/scaler/scaler-core/test/scaling-methods/base.test.js
@@ -265,4 +265,22 @@ describe('#loopThroughSpannerMetrics', () => {
     spanner.metrics[0].should.have.property('margin');
     spanner.metrics[1].should.have.property('margin').and.equal(99);
   });
+
+  it('should clamp to a min number of PU based on currentNumDatabases', () => {
+    const spanner = /** @type {AutoscalerSpanner} */ ({
+      units: 'PROCESSING_UNITS',
+      minSize: 100,
+      currentNumDatabases: 55,
+      currentSize: 1000,
+      maxSize: 2000,
+      metrics: [
+        {name: 'high_priority_cpu', threshold: 65, value: 10},
+        {name: 'rolling_24_hr', threshold: 90, value: 10},
+      ],
+    });
+
+    // Metrics suggest 100PU, but 55 db's requires 600 PU
+    const suggestedSize = loopThroughSpannerMetrics(spanner, () => 100);
+    suggestedSize.should.be.equal(600);
+  });
 });

--- a/src/scaler/scaler-core/test/state.test.js
+++ b/src/scaler/scaler-core/test/state.test.js
@@ -104,6 +104,7 @@ const BASE_CONFIG = {
   maxSize: 200,
   stepSize: 10,
   overloadStepSize: 10,
+  currentNumDatabases: 1,
 };
 
 describe('stateFirestoreTests', () => {


### PR DESCRIPTION
Instances configured with <1000 PUs only support 10 DBs per 100 PUs so clamp the minimum size to the relevant number of PUs

Fixes #286