### PR TITLE
chore: improve markdown-link-checker speed

### DIFF
--- a/markdown-link-checker.json
+++ b/markdown-link-checker.json
@@ -1,0 +1,16 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^https://console.cloud.google.com/"
+    },
+    {
+      "pattern": "^https://example.org"
+    }
+  ],
+  "replacementPatterns": [
+    {
+      "pattern": "^([./].*)/(#.*)?$",
+      "replacement": "$1/__LOCAL_URL_MUST_END_IN_FILENAME_NOT_RAW_PATH__$2"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "eslint-fix": "eslint --fix .",
     "format": "prettier --write .",
     "install-all": "npm install --save",
-    "markdown-link-check": "find . -name '*.md' -not \\( -path './node_modules/*' -o -path '*/.terraform/*' -prune \\) -print0 | xargs --null -n1 markdown-link-check --quiet",
+    "markdown-link-check": "find . -name '*.md' -not \\( -path './node_modules/*' -o -path '*/.terraform/*' -o -path './CHANGELOG.md' -prune \\) -print0 | xargs --null markdown-link-check --config markdown-link-checker.json --quiet",
     "mdlint": "markdownlint '**/*.md' --config .mdl.json --ignore '**/node_modules/**' --ignore 'code-of-conduct.md' --ignore 'CHANGELOG.md'",
     "poller-job": "node -e \"require('./src/poller/index').main()\"",
     "prepare": "{ git rev-parse --is-inside-work-tree >/dev/null 2>/dev/null && test \"$NODE_ENV\" != production -a \"$CI\" != true && husky ; }  || true",

--- a/terraform/gke/README.md
+++ b/terraform/gke/README.md
@@ -700,7 +700,7 @@ following the instructions above.
 <!-- LINKS: https://www.markdownguide.org/basic-syntax/#reference-style-links -->
 [architecture-gke]: ../../resources/architecture-gke.png
 [autoscaler-poller]: ../../src/poller/README.md
-[autoscaler-config-params]: ../../src/poller/#configuration-parameters
+[autoscaler-config-params]: ../../src/poller/README.md#configuration-parameters
 [cron-frequent]: ../../kubernetes/decoupled/autoscaler-pkg/poller/poller.yaml
 [cron-hourly]: ../../kubernetes/decoupled/autoscaler-pkg/poller/poller-hourly.yaml
 [margins]: ../../src/poller/README.md#margins


### PR DESCRIPTION
ignore CHANGELOG.md file and links to console.cloud.google.com