### PR TITLE
chore(deps): Bulk update of Renovate bumps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,13 +48,13 @@
         "lodash": "^4.17.21",
         "markdown-link-check": "^3.12.2",
         "markdownlint-cli": "^0.41.0",
-        "mocha": "^10.5.2",
+        "mocha": "^10.6.0",
         "nyc": "^15.1.0",
         "prettier": "^3.3.2",
         "rewire": "^7.0.0",
         "should": "^13.2.3",
         "sinon": "^17.0.1",
-        "typescript": "^5.5.2"
+        "typescript": "^5.5.3"
       },
       "engines": {
         "node": ">=18.0.0 || >=20.0.0",
@@ -2270,10 +2270,11 @@
       }
     },
     "node_modules/ansi-colors": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -3290,10 +3291,11 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -6441,31 +6443,32 @@
       }
     },
     "node_modules/mocha": {
-      "version": "10.5.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.5.2.tgz",
-      "integrity": "sha512-9btlN3JKCefPf+vKd/kcKz2SXxi12z6JswkGfaAF0saQvnsqLJk504ZmbxhSoENge08E9dsymozKgFMTl5PQsA==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.6.0.tgz",
+      "integrity": "sha512-hxjt4+EEB0SA0ZDygSS015t65lJw/I2yRCS3Ae+SJ5FrbzrXgfYwJr96f0OvIXdj7h4lv/vLCrH3rkiuizFSvw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ansi-colors": "4.1.1",
-        "browser-stdout": "1.3.1",
+        "ansi-colors": "^4.1.3",
+        "browser-stdout": "^1.3.1",
         "chokidar": "^3.5.3",
-        "debug": "4.3.4",
-        "diff": "5.0.0",
-        "escape-string-regexp": "4.0.0",
-        "find-up": "5.0.0",
-        "glob": "8.1.0",
-        "he": "1.2.0",
-        "js-yaml": "4.1.0",
-        "log-symbols": "4.1.0",
-        "minimatch": "5.0.1",
-        "ms": "2.1.3",
-        "serialize-javascript": "6.0.0",
-        "strip-json-comments": "3.1.1",
-        "supports-color": "8.1.1",
-        "workerpool": "6.2.1",
-        "yargs": "16.2.0",
-        "yargs-parser": "20.2.4",
-        "yargs-unparser": "2.0.0"
+        "debug": "^4.3.5",
+        "diff": "^5.2.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^8.1.0",
+        "he": "^1.2.0",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^5.1.6",
+        "ms": "^2.1.3",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^6.5.1",
+        "yargs": "^16.2.0",
+        "yargs-parser": "^20.2.9",
+        "yargs-unparser": "^2.0.0"
       },
       "bin": {
         "_mocha": "bin/_mocha",
@@ -6480,6 +6483,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -6495,6 +6499,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -6504,6 +6509,7 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -6515,6 +6521,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -6526,13 +6533,15 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mocha/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -6549,19 +6558,22 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mocha/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mocha/node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -6579,6 +6591,7 @@
       "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -6598,6 +6611,7 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -6609,10 +6623,11 @@
       }
     },
     "node_modules/mocha/node_modules/minimatch": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -6624,13 +6639,15 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mocha/node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -6646,6 +6663,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -6661,6 +6679,7 @@
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -6670,6 +6689,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -6684,6 +6704,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -6701,6 +6722,7 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
       "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -6719,6 +6741,7 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -8437,10 +8460,11 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -8611,15 +8635,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/sinon"
-      }
-    },
-    "node_modules/sinon/node_modules/diff": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/sinon/node_modules/supports-color": {
@@ -9281,10 +9296,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
-      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9494,10 +9510,11 @@
       }
     },
     "node_modules/workerpool": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
-      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
-      "dev": true
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
@@ -9677,10 +9694,11 @@
       }
     },
     "node_modules/yargs-parser": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=10"
       }

--- a/package.json
+++ b/package.json
@@ -70,13 +70,13 @@
     "lodash": "^4.17.21",
     "markdown-link-check": "^3.12.2",
     "markdownlint-cli": "^0.41.0",
-    "mocha": "^10.5.2",
+    "mocha": "^10.6.0",
     "nyc": "^15.1.0",
     "prettier": "^3.3.2",
     "rewire": "^7.0.0",
     "should": "^13.2.3",
     "sinon": "^17.0.1",
-    "typescript": "^5.5.2"
+    "typescript": "^5.5.3"
   },
   "engines": {
     "node": ">=18.0.0 || >=20.0.0",

--- a/terraform/cloud-functions/distributed/app-project/.terraform.lock.hcl
+++ b/terraform/cloud-functions/distributed/app-project/.terraform.lock.hcl
@@ -21,31 +21,31 @@ provider "registry.terraform.io/hashicorp/archive" {
 }
 
 provider "registry.terraform.io/hashicorp/google" {
-  version     = "5.35.0"
-  constraints = "~> 5.35.0"
+  version     = "5.36.0"
+  constraints = "~> 5.36.0"
   hashes = [
-    "h1:13jmPb7jkqOLOlHGhFXdgUuyhnyZPdcD4CjfOcdix44=",
-    "h1:JXpLirvlfvfj/wPAphej1UppXGiOOGEF3t5+um+x5tQ=",
-    "h1:L68kO8MYqhIDxO7R8/Tl8QAAfEcoCrfZXOe23fcC36g=",
-    "h1:MRHc3P5AxlEqfGJv0u/lFHSPWZoh9QBMo+gC9xzSCD4=",
-    "h1:QVdnGDcU/icidWhx4RktgvUL+OPa5lndG//OhkJBKCs=",
-    "h1:SLszneZGG8/G+TV2hN2T04ShKDg0/d+4l904kjOzGKc=",
-    "h1:W/Yn8s6caSGe7h+P0EmwTArmnzvHkXoeRY/TCawAyQU=",
-    "h1:XGV6aLcZ/Uk19j5pja1Cuv3UsX+lGzxrml4wVIF8hz8=",
-    "h1:hBK5VuphCHVuVekAXXwvf6F0wJ9yk9B+mkg12234nmo=",
-    "h1:l5Q8jJ3tiMbxOnoy/IDWmc8Es67VIV0VlVemYX93MYE=",
-    "h1:uNtHv4YZNoCyiMGK2XVnOIHqmEuwp4OETUxhKFDySS0=",
-    "zh:431c5bc9a92624700d0e9075b7c36818820c166e969beab4b27fd4311422ca6d",
-    "zh:529fd3b349883b5e28a2f6c7bff492fb70175c8f2b6897e8b9a0f15acf01b622",
-    "zh:53efb78e7bc9b907fc85a5b2d2160a8edf87f841e914b33feb8302d5de3bc46b",
-    "zh:5db3fe8b4d6eec7c28a0075e799ce0913f590f4cdb133f3e7632859c54a0431b",
-    "zh:6ede76c16d6effae4fd01192fa7a2ebd67a6516afd36d03c461819f3fb38072c",
-    "zh:8779c9bc49377478dd50ab5d7c79e40f980f1abf37df19438e320b3b86b8cc1a",
-    "zh:87bca22479f75bec3e797da22d6cf3d183ca0df47fb9fe77568154a94f59b221",
-    "zh:ae0469de578ba1f83c4c5c1221065ea87ac2acffb626b4a0961106b8ce12fabc",
-    "zh:b9536af2ff53f4f4cc6735369d994c6ce7bd1de710f2f69e7c166f771bf429d3",
-    "zh:c83a31ba66af78a0e77621f92ed4d4225ebdd6331876013b505e7f6e93aed96c",
-    "zh:d7b2a5aa65597de0c93a62e2a08be261170af4ed7b53fbdd42700b9a6e79ce89",
+    "h1:BuncIFDoC80vjZsuO/tI/W1nzCMg8ojobUj5yA81Q0s=",
+    "h1:CE+r73x4gsus1y0e/gHjhFNksawjsr/okjjpyYv29N4=",
+    "h1:PfA6oYc44QTUXqo5de+U5Io4vpXxiM0jMhEIrYbm74o=",
+    "h1:R9L9jFcgnsW43R8C9vAhd/FObHq+hAQFZhTZRtYbizU=",
+    "h1:Ulo187RYb/ibPvfrZYNTWlZvpI9yDQxKaUXPHjVrtgw=",
+    "h1:ZEMkbWcaEqnSb6UQhMXFzs6B2xDgvbKlkBIrrk862V8=",
+    "h1:ZmehutpLnGCVqxWhEZo8xLbggHjD39xvwefw4TwMt9g=",
+    "h1:bhfs330dNtA0MP502kARP9UtMl4kAaU3pY1kD98zL+U=",
+    "h1:m3BG0LNj4bzvUT3EIBWxGppEwOwsJJ/gErEqhvC2+qY=",
+    "h1:oxuPbaYigcl/K6eRk64WgAOmtc0p/IsVZ5+tED7LETY=",
+    "h1:wlDnHxKGnpX/Gx07qsTGHMEFkHOVvx/zyKJ143xxMvI=",
+    "zh:091f4e82ee4ba77cd37b67d9c24448a1317e8e103bd5f3191f7b4b26b314f2e6",
+    "zh:15aed0b4cc85ee275aa32740ecf745f4ff6da09ed7c705900d93f5d0e454fcd1",
+    "zh:403cc4daf32aa31fe89940aca6d1d320531103801d5c4678107f3c952d126875",
+    "zh:539c774fb97bc2dd6cd67f436ae062c2fc50d9181aa4f4ae626dc428dce1bb82",
+    "zh:5857cf533a5db0853f81f2662681e95556b0972cae0bd5cff02d24f2a0cb395e",
+    "zh:7e802ee04b9ea84f1667ac8e970dc559709628555e1350b4996f07b067da041d",
+    "zh:90a62593c84543f8d8f7848ae3b75d3190e6ad36cf38e2d5ca321771668c77e6",
+    "zh:9e2cf799c61dd4f534f84705db3ab00142d0a5b58ea147a6a67f5bd902f31eba",
+    "zh:b3470f63ef5621eab6501c7024ba74480def676cb58331755484ffcf1c64b3d8",
+    "zh:b6a640f7cbee78880e901512d193e6863339eb18f552903e7298ceb023543486",
+    "zh:cddaca8c950334a22849b6499c0dde289ac8e9767d29ee1504e70872201d8da8",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/terraform/cloud-functions/distributed/app-project/main.tf
+++ b/terraform/cloud-functions/distributed/app-project/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.35.0"
+      version = "~> 5.36.0"
     }
   }
 }

--- a/terraform/cloud-functions/distributed/autoscaler-project/.terraform.lock.hcl
+++ b/terraform/cloud-functions/distributed/autoscaler-project/.terraform.lock.hcl
@@ -21,31 +21,31 @@ provider "registry.terraform.io/hashicorp/archive" {
 }
 
 provider "registry.terraform.io/hashicorp/google" {
-  version     = "5.35.0"
-  constraints = "~> 5.35.0"
+  version     = "5.36.0"
+  constraints = "~> 5.36.0"
   hashes = [
-    "h1:13jmPb7jkqOLOlHGhFXdgUuyhnyZPdcD4CjfOcdix44=",
-    "h1:JXpLirvlfvfj/wPAphej1UppXGiOOGEF3t5+um+x5tQ=",
-    "h1:L68kO8MYqhIDxO7R8/Tl8QAAfEcoCrfZXOe23fcC36g=",
-    "h1:MRHc3P5AxlEqfGJv0u/lFHSPWZoh9QBMo+gC9xzSCD4=",
-    "h1:QVdnGDcU/icidWhx4RktgvUL+OPa5lndG//OhkJBKCs=",
-    "h1:SLszneZGG8/G+TV2hN2T04ShKDg0/d+4l904kjOzGKc=",
-    "h1:W/Yn8s6caSGe7h+P0EmwTArmnzvHkXoeRY/TCawAyQU=",
-    "h1:XGV6aLcZ/Uk19j5pja1Cuv3UsX+lGzxrml4wVIF8hz8=",
-    "h1:hBK5VuphCHVuVekAXXwvf6F0wJ9yk9B+mkg12234nmo=",
-    "h1:l5Q8jJ3tiMbxOnoy/IDWmc8Es67VIV0VlVemYX93MYE=",
-    "h1:uNtHv4YZNoCyiMGK2XVnOIHqmEuwp4OETUxhKFDySS0=",
-    "zh:431c5bc9a92624700d0e9075b7c36818820c166e969beab4b27fd4311422ca6d",
-    "zh:529fd3b349883b5e28a2f6c7bff492fb70175c8f2b6897e8b9a0f15acf01b622",
-    "zh:53efb78e7bc9b907fc85a5b2d2160a8edf87f841e914b33feb8302d5de3bc46b",
-    "zh:5db3fe8b4d6eec7c28a0075e799ce0913f590f4cdb133f3e7632859c54a0431b",
-    "zh:6ede76c16d6effae4fd01192fa7a2ebd67a6516afd36d03c461819f3fb38072c",
-    "zh:8779c9bc49377478dd50ab5d7c79e40f980f1abf37df19438e320b3b86b8cc1a",
-    "zh:87bca22479f75bec3e797da22d6cf3d183ca0df47fb9fe77568154a94f59b221",
-    "zh:ae0469de578ba1f83c4c5c1221065ea87ac2acffb626b4a0961106b8ce12fabc",
-    "zh:b9536af2ff53f4f4cc6735369d994c6ce7bd1de710f2f69e7c166f771bf429d3",
-    "zh:c83a31ba66af78a0e77621f92ed4d4225ebdd6331876013b505e7f6e93aed96c",
-    "zh:d7b2a5aa65597de0c93a62e2a08be261170af4ed7b53fbdd42700b9a6e79ce89",
+    "h1:BuncIFDoC80vjZsuO/tI/W1nzCMg8ojobUj5yA81Q0s=",
+    "h1:CE+r73x4gsus1y0e/gHjhFNksawjsr/okjjpyYv29N4=",
+    "h1:PfA6oYc44QTUXqo5de+U5Io4vpXxiM0jMhEIrYbm74o=",
+    "h1:R9L9jFcgnsW43R8C9vAhd/FObHq+hAQFZhTZRtYbizU=",
+    "h1:Ulo187RYb/ibPvfrZYNTWlZvpI9yDQxKaUXPHjVrtgw=",
+    "h1:ZEMkbWcaEqnSb6UQhMXFzs6B2xDgvbKlkBIrrk862V8=",
+    "h1:ZmehutpLnGCVqxWhEZo8xLbggHjD39xvwefw4TwMt9g=",
+    "h1:bhfs330dNtA0MP502kARP9UtMl4kAaU3pY1kD98zL+U=",
+    "h1:m3BG0LNj4bzvUT3EIBWxGppEwOwsJJ/gErEqhvC2+qY=",
+    "h1:oxuPbaYigcl/K6eRk64WgAOmtc0p/IsVZ5+tED7LETY=",
+    "h1:wlDnHxKGnpX/Gx07qsTGHMEFkHOVvx/zyKJ143xxMvI=",
+    "zh:091f4e82ee4ba77cd37b67d9c24448a1317e8e103bd5f3191f7b4b26b314f2e6",
+    "zh:15aed0b4cc85ee275aa32740ecf745f4ff6da09ed7c705900d93f5d0e454fcd1",
+    "zh:403cc4daf32aa31fe89940aca6d1d320531103801d5c4678107f3c952d126875",
+    "zh:539c774fb97bc2dd6cd67f436ae062c2fc50d9181aa4f4ae626dc428dce1bb82",
+    "zh:5857cf533a5db0853f81f2662681e95556b0972cae0bd5cff02d24f2a0cb395e",
+    "zh:7e802ee04b9ea84f1667ac8e970dc559709628555e1350b4996f07b067da041d",
+    "zh:90a62593c84543f8d8f7848ae3b75d3190e6ad36cf38e2d5ca321771668c77e6",
+    "zh:9e2cf799c61dd4f534f84705db3ab00142d0a5b58ea147a6a67f5bd902f31eba",
+    "zh:b3470f63ef5621eab6501c7024ba74480def676cb58331755484ffcf1c64b3d8",
+    "zh:b6a640f7cbee78880e901512d193e6863339eb18f552903e7298ceb023543486",
+    "zh:cddaca8c950334a22849b6499c0dde289ac8e9767d29ee1504e70872201d8da8",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/terraform/cloud-functions/distributed/autoscaler-project/main.tf
+++ b/terraform/cloud-functions/distributed/autoscaler-project/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.35.0"
+      version = "~> 5.36.0"
     }
   }
 }

--- a/terraform/cloud-functions/per-project/.terraform.lock.hcl
+++ b/terraform/cloud-functions/per-project/.terraform.lock.hcl
@@ -21,31 +21,31 @@ provider "registry.terraform.io/hashicorp/archive" {
 }
 
 provider "registry.terraform.io/hashicorp/google" {
-  version     = "5.35.0"
-  constraints = "~> 5.35.0"
+  version     = "5.36.0"
+  constraints = "~> 5.36.0"
   hashes = [
-    "h1:13jmPb7jkqOLOlHGhFXdgUuyhnyZPdcD4CjfOcdix44=",
-    "h1:JXpLirvlfvfj/wPAphej1UppXGiOOGEF3t5+um+x5tQ=",
-    "h1:L68kO8MYqhIDxO7R8/Tl8QAAfEcoCrfZXOe23fcC36g=",
-    "h1:MRHc3P5AxlEqfGJv0u/lFHSPWZoh9QBMo+gC9xzSCD4=",
-    "h1:QVdnGDcU/icidWhx4RktgvUL+OPa5lndG//OhkJBKCs=",
-    "h1:SLszneZGG8/G+TV2hN2T04ShKDg0/d+4l904kjOzGKc=",
-    "h1:W/Yn8s6caSGe7h+P0EmwTArmnzvHkXoeRY/TCawAyQU=",
-    "h1:XGV6aLcZ/Uk19j5pja1Cuv3UsX+lGzxrml4wVIF8hz8=",
-    "h1:hBK5VuphCHVuVekAXXwvf6F0wJ9yk9B+mkg12234nmo=",
-    "h1:l5Q8jJ3tiMbxOnoy/IDWmc8Es67VIV0VlVemYX93MYE=",
-    "h1:uNtHv4YZNoCyiMGK2XVnOIHqmEuwp4OETUxhKFDySS0=",
-    "zh:431c5bc9a92624700d0e9075b7c36818820c166e969beab4b27fd4311422ca6d",
-    "zh:529fd3b349883b5e28a2f6c7bff492fb70175c8f2b6897e8b9a0f15acf01b622",
-    "zh:53efb78e7bc9b907fc85a5b2d2160a8edf87f841e914b33feb8302d5de3bc46b",
-    "zh:5db3fe8b4d6eec7c28a0075e799ce0913f590f4cdb133f3e7632859c54a0431b",
-    "zh:6ede76c16d6effae4fd01192fa7a2ebd67a6516afd36d03c461819f3fb38072c",
-    "zh:8779c9bc49377478dd50ab5d7c79e40f980f1abf37df19438e320b3b86b8cc1a",
-    "zh:87bca22479f75bec3e797da22d6cf3d183ca0df47fb9fe77568154a94f59b221",
-    "zh:ae0469de578ba1f83c4c5c1221065ea87ac2acffb626b4a0961106b8ce12fabc",
-    "zh:b9536af2ff53f4f4cc6735369d994c6ce7bd1de710f2f69e7c166f771bf429d3",
-    "zh:c83a31ba66af78a0e77621f92ed4d4225ebdd6331876013b505e7f6e93aed96c",
-    "zh:d7b2a5aa65597de0c93a62e2a08be261170af4ed7b53fbdd42700b9a6e79ce89",
+    "h1:BuncIFDoC80vjZsuO/tI/W1nzCMg8ojobUj5yA81Q0s=",
+    "h1:CE+r73x4gsus1y0e/gHjhFNksawjsr/okjjpyYv29N4=",
+    "h1:PfA6oYc44QTUXqo5de+U5Io4vpXxiM0jMhEIrYbm74o=",
+    "h1:R9L9jFcgnsW43R8C9vAhd/FObHq+hAQFZhTZRtYbizU=",
+    "h1:Ulo187RYb/ibPvfrZYNTWlZvpI9yDQxKaUXPHjVrtgw=",
+    "h1:ZEMkbWcaEqnSb6UQhMXFzs6B2xDgvbKlkBIrrk862V8=",
+    "h1:ZmehutpLnGCVqxWhEZo8xLbggHjD39xvwefw4TwMt9g=",
+    "h1:bhfs330dNtA0MP502kARP9UtMl4kAaU3pY1kD98zL+U=",
+    "h1:m3BG0LNj4bzvUT3EIBWxGppEwOwsJJ/gErEqhvC2+qY=",
+    "h1:oxuPbaYigcl/K6eRk64WgAOmtc0p/IsVZ5+tED7LETY=",
+    "h1:wlDnHxKGnpX/Gx07qsTGHMEFkHOVvx/zyKJ143xxMvI=",
+    "zh:091f4e82ee4ba77cd37b67d9c24448a1317e8e103bd5f3191f7b4b26b314f2e6",
+    "zh:15aed0b4cc85ee275aa32740ecf745f4ff6da09ed7c705900d93f5d0e454fcd1",
+    "zh:403cc4daf32aa31fe89940aca6d1d320531103801d5c4678107f3c952d126875",
+    "zh:539c774fb97bc2dd6cd67f436ae062c2fc50d9181aa4f4ae626dc428dce1bb82",
+    "zh:5857cf533a5db0853f81f2662681e95556b0972cae0bd5cff02d24f2a0cb395e",
+    "zh:7e802ee04b9ea84f1667ac8e970dc559709628555e1350b4996f07b067da041d",
+    "zh:90a62593c84543f8d8f7848ae3b75d3190e6ad36cf38e2d5ca321771668c77e6",
+    "zh:9e2cf799c61dd4f534f84705db3ab00142d0a5b58ea147a6a67f5bd902f31eba",
+    "zh:b3470f63ef5621eab6501c7024ba74480def676cb58331755484ffcf1c64b3d8",
+    "zh:b6a640f7cbee78880e901512d193e6863339eb18f552903e7298ceb023543486",
+    "zh:cddaca8c950334a22849b6499c0dde289ac8e9767d29ee1504e70872201d8da8",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/terraform/cloud-functions/per-project/main.tf
+++ b/terraform/cloud-functions/per-project/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.35.0"
+      version = "~> 5.36.0"
     }
   }
 }

--- a/terraform/gke/decoupled/.terraform.lock.hcl
+++ b/terraform/gke/decoupled/.terraform.lock.hcl
@@ -22,31 +22,31 @@ provider "registry.terraform.io/hashicorp/external" {
 }
 
 provider "registry.terraform.io/hashicorp/google" {
-  version     = "5.35.0"
-  constraints = ">= 3.39.0, >= 3.53.0, >= 5.9.0, ~> 5.35.0, < 6.0.0"
+  version     = "5.36.0"
+  constraints = ">= 3.39.0, >= 3.53.0, >= 5.9.0, ~> 5.36.0, < 6.0.0"
   hashes = [
-    "h1:13jmPb7jkqOLOlHGhFXdgUuyhnyZPdcD4CjfOcdix44=",
-    "h1:JXpLirvlfvfj/wPAphej1UppXGiOOGEF3t5+um+x5tQ=",
-    "h1:L68kO8MYqhIDxO7R8/Tl8QAAfEcoCrfZXOe23fcC36g=",
-    "h1:MRHc3P5AxlEqfGJv0u/lFHSPWZoh9QBMo+gC9xzSCD4=",
-    "h1:QVdnGDcU/icidWhx4RktgvUL+OPa5lndG//OhkJBKCs=",
-    "h1:SLszneZGG8/G+TV2hN2T04ShKDg0/d+4l904kjOzGKc=",
-    "h1:W/Yn8s6caSGe7h+P0EmwTArmnzvHkXoeRY/TCawAyQU=",
-    "h1:XGV6aLcZ/Uk19j5pja1Cuv3UsX+lGzxrml4wVIF8hz8=",
-    "h1:hBK5VuphCHVuVekAXXwvf6F0wJ9yk9B+mkg12234nmo=",
-    "h1:l5Q8jJ3tiMbxOnoy/IDWmc8Es67VIV0VlVemYX93MYE=",
-    "h1:uNtHv4YZNoCyiMGK2XVnOIHqmEuwp4OETUxhKFDySS0=",
-    "zh:431c5bc9a92624700d0e9075b7c36818820c166e969beab4b27fd4311422ca6d",
-    "zh:529fd3b349883b5e28a2f6c7bff492fb70175c8f2b6897e8b9a0f15acf01b622",
-    "zh:53efb78e7bc9b907fc85a5b2d2160a8edf87f841e914b33feb8302d5de3bc46b",
-    "zh:5db3fe8b4d6eec7c28a0075e799ce0913f590f4cdb133f3e7632859c54a0431b",
-    "zh:6ede76c16d6effae4fd01192fa7a2ebd67a6516afd36d03c461819f3fb38072c",
-    "zh:8779c9bc49377478dd50ab5d7c79e40f980f1abf37df19438e320b3b86b8cc1a",
-    "zh:87bca22479f75bec3e797da22d6cf3d183ca0df47fb9fe77568154a94f59b221",
-    "zh:ae0469de578ba1f83c4c5c1221065ea87ac2acffb626b4a0961106b8ce12fabc",
-    "zh:b9536af2ff53f4f4cc6735369d994c6ce7bd1de710f2f69e7c166f771bf429d3",
-    "zh:c83a31ba66af78a0e77621f92ed4d4225ebdd6331876013b505e7f6e93aed96c",
-    "zh:d7b2a5aa65597de0c93a62e2a08be261170af4ed7b53fbdd42700b9a6e79ce89",
+    "h1:BuncIFDoC80vjZsuO/tI/W1nzCMg8ojobUj5yA81Q0s=",
+    "h1:CE+r73x4gsus1y0e/gHjhFNksawjsr/okjjpyYv29N4=",
+    "h1:PfA6oYc44QTUXqo5de+U5Io4vpXxiM0jMhEIrYbm74o=",
+    "h1:R9L9jFcgnsW43R8C9vAhd/FObHq+hAQFZhTZRtYbizU=",
+    "h1:Ulo187RYb/ibPvfrZYNTWlZvpI9yDQxKaUXPHjVrtgw=",
+    "h1:ZEMkbWcaEqnSb6UQhMXFzs6B2xDgvbKlkBIrrk862V8=",
+    "h1:ZmehutpLnGCVqxWhEZo8xLbggHjD39xvwefw4TwMt9g=",
+    "h1:bhfs330dNtA0MP502kARP9UtMl4kAaU3pY1kD98zL+U=",
+    "h1:m3BG0LNj4bzvUT3EIBWxGppEwOwsJJ/gErEqhvC2+qY=",
+    "h1:oxuPbaYigcl/K6eRk64WgAOmtc0p/IsVZ5+tED7LETY=",
+    "h1:wlDnHxKGnpX/Gx07qsTGHMEFkHOVvx/zyKJ143xxMvI=",
+    "zh:091f4e82ee4ba77cd37b67d9c24448a1317e8e103bd5f3191f7b4b26b314f2e6",
+    "zh:15aed0b4cc85ee275aa32740ecf745f4ff6da09ed7c705900d93f5d0e454fcd1",
+    "zh:403cc4daf32aa31fe89940aca6d1d320531103801d5c4678107f3c952d126875",
+    "zh:539c774fb97bc2dd6cd67f436ae062c2fc50d9181aa4f4ae626dc428dce1bb82",
+    "zh:5857cf533a5db0853f81f2662681e95556b0972cae0bd5cff02d24f2a0cb395e",
+    "zh:7e802ee04b9ea84f1667ac8e970dc559709628555e1350b4996f07b067da041d",
+    "zh:90a62593c84543f8d8f7848ae3b75d3190e6ad36cf38e2d5ca321771668c77e6",
+    "zh:9e2cf799c61dd4f534f84705db3ab00142d0a5b58ea147a6a67f5bd902f31eba",
+    "zh:b3470f63ef5621eab6501c7024ba74480def676cb58331755484ffcf1c64b3d8",
+    "zh:b6a640f7cbee78880e901512d193e6863339eb18f552903e7298ceb023543486",
+    "zh:cddaca8c950334a22849b6499c0dde289ac8e9767d29ee1504e70872201d8da8",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/terraform/gke/decoupled/main.tf
+++ b/terraform/gke/decoupled/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.35.0"
+      version = "~> 5.36.0"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"

--- a/terraform/gke/unified/.terraform.lock.hcl
+++ b/terraform/gke/unified/.terraform.lock.hcl
@@ -22,31 +22,31 @@ provider "registry.terraform.io/hashicorp/external" {
 }
 
 provider "registry.terraform.io/hashicorp/google" {
-  version     = "5.35.0"
-  constraints = ">= 3.39.0, >= 3.53.0, >= 5.9.0, ~> 5.35.0, < 6.0.0"
+  version     = "5.36.0"
+  constraints = ">= 3.39.0, >= 3.53.0, >= 5.9.0, ~> 5.36.0, < 6.0.0"
   hashes = [
-    "h1:13jmPb7jkqOLOlHGhFXdgUuyhnyZPdcD4CjfOcdix44=",
-    "h1:JXpLirvlfvfj/wPAphej1UppXGiOOGEF3t5+um+x5tQ=",
-    "h1:L68kO8MYqhIDxO7R8/Tl8QAAfEcoCrfZXOe23fcC36g=",
-    "h1:MRHc3P5AxlEqfGJv0u/lFHSPWZoh9QBMo+gC9xzSCD4=",
-    "h1:QVdnGDcU/icidWhx4RktgvUL+OPa5lndG//OhkJBKCs=",
-    "h1:SLszneZGG8/G+TV2hN2T04ShKDg0/d+4l904kjOzGKc=",
-    "h1:W/Yn8s6caSGe7h+P0EmwTArmnzvHkXoeRY/TCawAyQU=",
-    "h1:XGV6aLcZ/Uk19j5pja1Cuv3UsX+lGzxrml4wVIF8hz8=",
-    "h1:hBK5VuphCHVuVekAXXwvf6F0wJ9yk9B+mkg12234nmo=",
-    "h1:l5Q8jJ3tiMbxOnoy/IDWmc8Es67VIV0VlVemYX93MYE=",
-    "h1:uNtHv4YZNoCyiMGK2XVnOIHqmEuwp4OETUxhKFDySS0=",
-    "zh:431c5bc9a92624700d0e9075b7c36818820c166e969beab4b27fd4311422ca6d",
-    "zh:529fd3b349883b5e28a2f6c7bff492fb70175c8f2b6897e8b9a0f15acf01b622",
-    "zh:53efb78e7bc9b907fc85a5b2d2160a8edf87f841e914b33feb8302d5de3bc46b",
-    "zh:5db3fe8b4d6eec7c28a0075e799ce0913f590f4cdb133f3e7632859c54a0431b",
-    "zh:6ede76c16d6effae4fd01192fa7a2ebd67a6516afd36d03c461819f3fb38072c",
-    "zh:8779c9bc49377478dd50ab5d7c79e40f980f1abf37df19438e320b3b86b8cc1a",
-    "zh:87bca22479f75bec3e797da22d6cf3d183ca0df47fb9fe77568154a94f59b221",
-    "zh:ae0469de578ba1f83c4c5c1221065ea87ac2acffb626b4a0961106b8ce12fabc",
-    "zh:b9536af2ff53f4f4cc6735369d994c6ce7bd1de710f2f69e7c166f771bf429d3",
-    "zh:c83a31ba66af78a0e77621f92ed4d4225ebdd6331876013b505e7f6e93aed96c",
-    "zh:d7b2a5aa65597de0c93a62e2a08be261170af4ed7b53fbdd42700b9a6e79ce89",
+    "h1:BuncIFDoC80vjZsuO/tI/W1nzCMg8ojobUj5yA81Q0s=",
+    "h1:CE+r73x4gsus1y0e/gHjhFNksawjsr/okjjpyYv29N4=",
+    "h1:PfA6oYc44QTUXqo5de+U5Io4vpXxiM0jMhEIrYbm74o=",
+    "h1:R9L9jFcgnsW43R8C9vAhd/FObHq+hAQFZhTZRtYbizU=",
+    "h1:Ulo187RYb/ibPvfrZYNTWlZvpI9yDQxKaUXPHjVrtgw=",
+    "h1:ZEMkbWcaEqnSb6UQhMXFzs6B2xDgvbKlkBIrrk862V8=",
+    "h1:ZmehutpLnGCVqxWhEZo8xLbggHjD39xvwefw4TwMt9g=",
+    "h1:bhfs330dNtA0MP502kARP9UtMl4kAaU3pY1kD98zL+U=",
+    "h1:m3BG0LNj4bzvUT3EIBWxGppEwOwsJJ/gErEqhvC2+qY=",
+    "h1:oxuPbaYigcl/K6eRk64WgAOmtc0p/IsVZ5+tED7LETY=",
+    "h1:wlDnHxKGnpX/Gx07qsTGHMEFkHOVvx/zyKJ143xxMvI=",
+    "zh:091f4e82ee4ba77cd37b67d9c24448a1317e8e103bd5f3191f7b4b26b314f2e6",
+    "zh:15aed0b4cc85ee275aa32740ecf745f4ff6da09ed7c705900d93f5d0e454fcd1",
+    "zh:403cc4daf32aa31fe89940aca6d1d320531103801d5c4678107f3c952d126875",
+    "zh:539c774fb97bc2dd6cd67f436ae062c2fc50d9181aa4f4ae626dc428dce1bb82",
+    "zh:5857cf533a5db0853f81f2662681e95556b0972cae0bd5cff02d24f2a0cb395e",
+    "zh:7e802ee04b9ea84f1667ac8e970dc559709628555e1350b4996f07b067da041d",
+    "zh:90a62593c84543f8d8f7848ae3b75d3190e6ad36cf38e2d5ca321771668c77e6",
+    "zh:9e2cf799c61dd4f534f84705db3ab00142d0a5b58ea147a6a67f5bd902f31eba",
+    "zh:b3470f63ef5621eab6501c7024ba74480def676cb58331755484ffcf1c64b3d8",
+    "zh:b6a640f7cbee78880e901512d193e6863339eb18f552903e7298ceb023543486",
+    "zh:cddaca8c950334a22849b6499c0dde289ac8e9767d29ee1504e70872201d8da8",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/terraform/gke/unified/main.tf
+++ b/terraform/gke/unified/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.35.0"
+      version = "~> 5.36.0"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"

--- a/terraform/modules/autoscaler-cluster/main.tf
+++ b/terraform/modules/autoscaler-cluster/main.tf
@@ -127,7 +127,7 @@ resource "kubernetes_namespace" "autoscaler_namespace" {
 module "workload_identity_poller" {
   count               = var.unified_components ? 0 : 1
   source              = "terraform-google-modules/kubernetes-engine/google//modules/workload-identity"
-  version             = "~> 31.0.0"
+  version             = "~> 31.1.0"
 
   project_id          = var.project_id
   namespace           = "spanner-autoscaler"
@@ -139,7 +139,7 @@ module "workload_identity_poller" {
 
 module "workload_identity_scaler" {
   source              = "terraform-google-modules/kubernetes-engine/google//modules/workload-identity"
-  version             = "~> 31.0.0"
+  version             = "~> 31.1.0"
 
   project_id          = var.project_id
   namespace           = "spanner-autoscaler"
@@ -152,7 +152,7 @@ module "workload_identity_scaler" {
 
 module "workload_identity_otel_collector" {
   source              = "terraform-google-modules/kubernetes-engine/google//modules/workload-identity"
-  version             = "~> 31.0.0"
+  version             = "~> 31.1.0"
 
   project_id          = var.project_id
   namespace           = "spanner-autoscaler"
@@ -165,7 +165,7 @@ module "workload_identity_otel_collector" {
 
 module "cluster" {
   source                 = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
-  version                = "~> 31.0.0"
+  version                = "~> 31.1.0"
 
   project_id             = var.project_id
   name                   = var.name


### PR DESCRIPTION
chore(deps): update dependency mocha to ^10.6.0

chore(deps): update terraform terraform-google-modules/kubernetes-engine/google to ~> 31.1.0

chore(deps): update dependency typescript to ^5.5.3

chore(deps): update terraform google to ~> 5.36.0

replaces #337, #336, #335, #334