### PR TITLE
feat!: Add scaling duration dashboard

### DIFF
--- a/src/autoscaler-common/counters_base.js
+++ b/src/autoscaler-common/counters_base.js
@@ -288,7 +288,7 @@ async function initMetrics() {
     } else {
       exporterMode = ExporterMode.GCM_ONLY_FLUSHING;
       logger.info(`Counters mode: ${exporterMode} using GCP monitoring`);
-      exporter = new GcpMetricExporter({prefix: 'custom.googleapis.com'});
+      exporter = new GcpMetricExporter({prefix: 'workload.googleapis.com'});
     }
 
     meterProvider = new MeterProvider({

--- a/terraform/modules/monitoring/dashboard.json.tftpl
+++ b/terraform/modules/monitoring/dashboard.json.tftpl
@@ -1,5 +1,5 @@
 {
-  "displayName": "spanner autoscaler dashboard",
+  "displayName": "Spanner Autoscaler Dashboard",
   "mosaicLayout": {
     "columns": 12,
     "tiles": [
@@ -183,6 +183,45 @@
         "width": 6,
         "xPos": 6,
         "yPos": 4
+      },
+      {
+        "yPos": 8,
+        "width": 6,
+        "height": 4,
+        "widget": {
+          "title": "Scaling Duration",
+          "xyChart": {
+            "chartOptions": {
+              "mode": "COLOR"
+            },
+            "dataSets": [
+              {
+                "minAlignmentPeriod": "60s",
+                "plotType": "LINE",
+                "targetAxis": "Y1",
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "aggregation": {
+                      "alignmentPeriod": "60s",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_99",
+                      "groupByFields": [
+                        "metric.label.\"scaling_method\"",
+                        "metric.label.\"scaling_direction\"",
+                        "metric.label.\"spanner_instance_id\""
+                      ],
+                      "perSeriesAligner": "ALIGN_DELTA"
+                    },
+                    "filter": "metric.type=\"workload.googleapis.com/cloudspannerecosystem/autoscaler/scaler/scaling-duration\""
+                  }
+                }
+              }
+            ],
+            "yAxis": {
+              "label": "y1Axis",
+              "scale": "LINEAR"
+            }
+          }
+        }
       }
     ]
   }


### PR DESCRIPTION
This additionally updates the metrics domain used by the Cloud Functions deployment from `custom.googleapis.com` to `workload.googleapis.com` (to match the GCP Metrics exporter for the OpenTelemetry collector).