### PR TITLE
fix: Populate OpenTelemetry compression parameter

### DIFF
--- a/src/autoscaler-common/counters_base.js
+++ b/src/autoscaler-common/counters_base.js
@@ -284,7 +284,11 @@ async function initMetrics() {
       logger.info(
         `Counters mode: ${exporterMode} OTEL collector: ${process.env.OTEL_COLLECTOR_URL}`,
       );
-      exporter = new OTLPMetricExporter({url: process.env.OTEL_COLLECTOR_URL});
+      exporter = new OTLPMetricExporter({
+        url: process.env.OTEL_COLLECTOR_URL,
+        // @ts-ignore -- CompressionAlgorithm.NONE (='none') is not exported.
+        compression: 'none',
+      });
     } else {
       exporterMode = ExporterMode.GCM_ONLY_FLUSHING;
       logger.info(`Counters mode: ${exporterMode} using GCP monitoring`);


### PR DESCRIPTION
This is to remove a persistent `WARNING` level logline in the Cloud Logging output for GKE deployment.