### PR TITLE
fix: Use lightweight Spanner call to address memory leak

### DIFF
--- a/src/poller/poller-core/index.js
+++ b/src/poller/poller-core/index.js
@@ -276,9 +276,11 @@ async function getSpannerMetadata(projectId, spannerInstanceId, units) {
 
   try {
     const spannerInstance = spanner.instance(spannerInstanceId);
-
+    const databaseAdminClient = spanner.getDatabaseAdminClient();
     const results = await Promise.all([
-      spannerInstance.getDatabases(),
+      databaseAdminClient.listDatabases({
+        parent: databaseAdminClient.instancePath(projectId, spannerInstanceId),
+      }),
       spannerInstance.getMetadata(),
     ]);
     const numDatabases = results[0][0].length;


### PR DESCRIPTION
This PR fixes a memory leak affecting the Poller component, which resulted in an increasing amount of memory consumed until the Cloud Functions instance memory limit was exceeded, and the instance was terminated. The `getDatabases` call returns an array of database objects -- by using a different call to the Spanner API to retrieve the number of databases for each instance, no resources are left waiting to be freed. Fixes #376. 