### PR TITLE
fix: add resource requests/limits to otel collector

### DIFF
--- a/kubernetes/decoupled/autoscaler-pkg/otel-collector/otel-collector.yaml
+++ b/kubernetes/decoupled/autoscaler-pkg/otel-collector/otel-collector.yaml
@@ -18,6 +18,12 @@ spec:
       containers:
         - name: otel-collector
           image: otel/opentelemetry-collector-contrib:0.93.0
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "250m"
+            limits:
+              memory: "256Mi"
           args:
             - --config
             - /etc/otel/config.yaml

--- a/kubernetes/unified/autoscaler-pkg/otel-collector/otel-collector.yaml
+++ b/kubernetes/unified/autoscaler-pkg/otel-collector/otel-collector.yaml
@@ -18,6 +18,12 @@ spec:
       containers:
         - name: otel-collector
           image: otel/opentelemetry-collector-contrib:0.93.0
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "250m"
+            limits:
+              memory: "256Mi"
           args:
             - --config
             - /etc/otel/config.yaml


### PR DESCRIPTION
This is mostly for completeness, as the resource utilization is minimal for this level of telemetry.