### PR TITLE
fix(tf): allow build SA to read AR

### DIFF
--- a/terraform/modules/autoscaler-base/main.tf
+++ b/terraform/modules/autoscaler-base/main.tf
@@ -73,6 +73,7 @@ resource "google_service_account" "build_sa" {
 
 resource "google_project_iam_member" "build_iam" {
   for_each = toset([
+    "roles/artifactregistry.reader",
     "roles/artifactregistry.writer",
     "roles/logging.logWriter",
     "roles/storage.objectViewer",


### PR DESCRIPTION
This is to enable checks for cached images from previous builds.