### PR TITLE
feat: parameterize Cloud Run functions available CPU

### DIFF
--- a/terraform/modules/autoscaler-functions/main.tf
+++ b/terraform/modules/autoscaler-functions/main.tf
@@ -120,6 +120,7 @@ resource "google_cloudfunctions2_function" "poller_function" {
 
   service_config {
     available_memory      = "256M"
+    available_cpu         = var.poller_function_available_cpu
     ingress_settings      = "ALLOW_INTERNAL_AND_GCLB"
     service_account_email = var.poller_sa_email
   }
@@ -157,6 +158,7 @@ resource "google_cloudfunctions2_function" "scaler_function" {
 
   service_config {
     available_memory      = "256M"
+    available_cpu         = var.scaler_function_available_cpu
     ingress_settings      = "ALLOW_INTERNAL_AND_GCLB"
     service_account_email = var.scaler_sa_email
   }

--- a/terraform/modules/autoscaler-functions/variables.tf
+++ b/terraform/modules/autoscaler-functions/variables.tf
@@ -55,3 +55,23 @@ variable "forwarder_sa_emails" {
   // Example ["serviceAccount:forwarder_sa@app-project.iam.gserviceaccount.com"]
   default = []
 }
+
+variable "poller_function_available_cpu" {
+  type        = number
+  default     = null
+  description = "The amount of available CPU for the poller function. Unset/null will allow Cloud Run to default based on Memory."
+  validation {
+    condition     = var.poller_function_available_cpu == null ? true : var.poller_function_available_cpu >= 0.08
+    error_message = "The minimum value for poller_function_available_cpu is 0.08."
+  }
+}
+
+variable "scaler_function_available_cpu" {
+  type        = number
+  default     = null
+  description = "The amount of available CPU for the scaler function. Unset/null will allow Cloud Run to default based on Memory."
+  validation {
+    condition     = var.scaler_function_available_cpu == null ? true : var.scaler_function_available_cpu >= 0.08
+    error_message = "The minimum value for scaler_function_available_cpu is 0.08."
+  }
+}


### PR DESCRIPTION
By default the container gets assigned 167m CPU. 

For us: moving to the min (0.08) results in ~50% cost savings and small increase in runtime.

Partially address https://github.com/cloudspannerecosystem/autoscaler/issues/440

<details>
<summary>BEFORE</summary>

Mean runtime 7.8s

Container CPU
<img width="536" alt="Screenshot 2025-02-10 at 11 34 24" src="https://github.com/user-attachments/assets/30ed41b0-0009-4341-9ef6-ccfb89fecabd" />


<img width="1563" alt="runtime-default-cpu" src="https://github.com/user-attachments/assets/70c0f3b1-6e77-4e23-9014-bff62a73a6e3" />
<img width="1529" alt="mean-default-cpu" src="https://github.com/user-attachments/assets/4133022b-6de9-4520-a5b0-62d8ea5fd0af" />

</details>


<details>
<summary>AFTER</summary>

Mean runtime 9.1s

<img width="1554" alt="runtime-min-cpu" src="https://github.com/user-attachments/assets/8fd7fdf4-d6b5-4e3c-a0b1-fb6a20e1fa7d" />
<img width="1536" alt="mean-min-cpu" src="https://github.com/user-attachments/assets/3af4f390-fc44-4538-93e6-c205eed6b5f7" />
</details>

