### PR TITLE
feat!: parameterize Cloud Run functions instance count 

### DIFF
--- a/terraform/modules/autoscaler-functions/main.tf
+++ b/terraform/modules/autoscaler-functions/main.tf
@@ -119,6 +119,7 @@ resource "google_cloudfunctions2_function" "poller_function" {
   }
 
   service_config {
+    max_instance_count    = var.poller_max_instance_count
     available_memory      = "256M"
     available_cpu         = var.poller_function_available_cpu
     ingress_settings      = "ALLOW_INTERNAL_AND_GCLB"
@@ -130,12 +131,6 @@ resource "google_cloudfunctions2_function" "poller_function" {
     pubsub_topic          = google_pubsub_topic.poller_topic.id
     retry_policy          = "RETRY_POLICY_RETRY"
     service_account_email = var.poller_sa_email
-  }
-
-  lifecycle {
-    ignore_changes = [
-      service_config[0].max_instance_count
-    ]
   }
 }
 
@@ -157,6 +152,7 @@ resource "google_cloudfunctions2_function" "scaler_function" {
   }
 
   service_config {
+    max_instance_count    = var.scaler_max_instance_count
     available_memory      = "256M"
     available_cpu         = var.scaler_function_available_cpu
     ingress_settings      = "ALLOW_INTERNAL_AND_GCLB"
@@ -168,12 +164,6 @@ resource "google_cloudfunctions2_function" "scaler_function" {
     pubsub_topic          = google_pubsub_topic.scaler_topic.id
     retry_policy          = "RETRY_POLICY_RETRY"
     service_account_email = var.scaler_sa_email
-  }
-
-  lifecycle {
-    ignore_changes = [
-      service_config[0].max_instance_count
-    ]
   }
 }
 

--- a/terraform/modules/autoscaler-functions/variables.tf
+++ b/terraform/modules/autoscaler-functions/variables.tf
@@ -56,6 +56,18 @@ variable "forwarder_sa_emails" {
   default = []
 }
 
+variable "scaler_max_instance_count" {
+  description = "Maximum number of instances for the scaler function"
+  type        = number
+  default     = null
+}
+
+variable "poller_max_instance_count" {
+  description = "Maximum number of instances for the poller function"
+  type        = number
+  default     = null
+}
+
 variable "poller_function_available_cpu" {
   type        = number
   default     = null


### PR DESCRIPTION
breaking change

The previous terraform configuration allowed users to update the max_instance_count of each function in the console and have terraform ignore the change. This change puts max_instance_count under terraform control and is therefore a breaking change for users who were relying on terraform never updating the value they set. It does not seem possible to ignore_changes selectively (EG if the max_instance_count var was null).

The default of null (which then defaults to 100 in Cloud Run) remains unchanged.

Partially address https://github.com/cloudspannerecosystem/autoscaler/issues/440

<details>
<summary>BEFORE</summary>

<img width="1546" alt="no-max-set-instance-count" src="https://github.com/user-attachments/assets/abb195e4-6146-4222-904a-8e5e32004e9f" />

</details>


<details>
<summary>AFTER</summary>

<img width="1820" alt="max-set-instance-count" src="https://github.com/user-attachments/assets/7ea3ee7f-6bcd-4ca9-90a4-7114e2dfa9ea" />

</details>
