### PR TITLE
feat: retrieve spanner instance metrics/metadata in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,5 +91,6 @@
     "glob": ">=13.0.6",
     "serialize-javascript": ">=7.0.5",
     "@tootallnate/once": ">=3.0.1"
-  }
+  },
+  "allowScripts": {}
 }

--- a/src/poller/poller-core/index.js
+++ b/src/poller/poller-core/index.js
@@ -404,8 +404,8 @@ async function callScalerHTTP(spanner, metrics) {
  */
 async function parseAndEnrichPayload(payload) {
   const spanners = await configValidator.parseAndAssertValidConfig(payload);
-  /** @type {AutoscalerSpanner[]} */
-  const spannersFound = [];
+  /** @type {Promise<AutoscalerSpanner?>[]} */
+  const spannersFoundPromises = [];
 
   for (let sIdx = 0; sIdx < spanners.length; sIdx++) {
     const metricOverrides =
@@ -467,29 +467,36 @@ async function parseAndEnrichPayload(payload) {
       }
     }
 
-    // merge in the current Spanner state
-    try {
-      spanners[sIdx] = {
-        ...spanners[sIdx],
-        ...(await getSpannerMetadata(
-          spanners[sIdx].projectId,
-          spanners[sIdx].instanceId,
-          spanners[sIdx].units.toUpperCase(),
-        )),
-      };
-      spannersFound.push(spanners[sIdx]);
-    } catch (err) {
-      logger.error({
-        message: `Unable to retrieve Spanner metadata for ${spanners[sIdx].projectId}/${spanners[sIdx].instanceId}: ${err}`,
-        projectId: spanners[sIdx].projectId,
-        instanceId: spanners[sIdx].instanceId,
-        err: err,
-        payload: spanners[sIdx],
-      });
-    }
+    // get spanner metadata asynchronously
+    /** @type {Promise<AutoscalerSpanner?>} */
+    const spannerFoundPromise = (async () => {
+      // merge in the current Spanner state
+      try {
+        spanners[sIdx] = {
+          ...spanners[sIdx],
+          ...(await getSpannerMetadata(
+            spanners[sIdx].projectId,
+            spanners[sIdx].instanceId,
+            spanners[sIdx].units.toUpperCase(),
+          )),
+        };
+        return spanners[sIdx];
+      } catch (err) {
+        logger.error({
+          message: `Unable to retrieve Spanner metadata for ${spanners[sIdx].projectId}/${spanners[sIdx].instanceId}: ${err}`,
+          projectId: spanners[sIdx].projectId,
+          instanceId: spanners[sIdx].instanceId,
+          err: err,
+          payload: spanners[sIdx],
+        });
+        return null;
+      }
+    })();
+    spannersFoundPromises.push(spannerFoundPromise);
   }
 
-  return spannersFound;
+  // wait for all to resolve and return an array with no nulls/undefineds.
+  return (await Promise.all(spannersFoundPromises)).filter((x) => x != null);
 }
 
 /**

--- a/src/poller/poller-core/test/index.test.js
+++ b/src/poller/poller-core/test/index.test.js
@@ -143,6 +143,26 @@ describe('#parseAndEnrichPayload', () => {
     unset();
   });
 
+  it('should skip an instance if metric retrieval failed', async () => {
+    const payload = JSON.stringify([
+      {
+        projectId: 'my-spanner-project',
+        instanceId: 'spanner1',
+        scalerPubSubTopic: 'projects/my-project/topics/spanner-scaling',
+        units: 'PROCESSING_UNITS',
+        minSize: 200,
+      },
+    ]);
+
+    const stub = sinon.stub().rejects('error');
+    const unset = app.__set__('getSpannerMetadata', stub);
+
+    const mergedConfig = await parseAndEnrichPayload(payload);
+    should(mergedConfig.length).equal(0);
+
+    unset();
+  });
+
   it('should use the value of minSize/maxSize for minNodes/maxNodes instead of overriding with the defaults, Github Issue 61', async () => {
     const payload = JSON.stringify([
       {


### PR DESCRIPTION
Where multiple spanner instances are specified in a autoscaler config, instead of synchronously retrieving each instances metrics/metadata in turn, retrieve them in parallel